### PR TITLE
Prevent css.d.ts files from triggering builds.

### DIFF
--- a/src/plugins/IgnoreUnmodifiedPlugin.ts
+++ b/src/plugins/IgnoreUnmodifiedPlugin.ts
@@ -1,0 +1,40 @@
+import Compiler = require('webpack/lib/Compiler');
+
+// TODO: See https://github.com/webpack/watchpack/issues/51
+// The first time webpack's file watcher comes across a new file, it adds 10s to its mtime,
+// and then emits change events until the compilation start time passes that mtime. The result
+// of this behavior is that when initially running `$ dojo build -w`, the app compiles multiple
+// times. This plugin works by removing the 10s buffer added to the file's mtime with the
+// initial pass.
+const FS_ACCURACY = 10000;
+
+export class IgnoreUnmodifiedPlugin {
+	apply(compiler: Compiler) {
+		compiler.plugin('after-environment', () => {
+			const wfs = compiler.watchFileSystem.wfs || compiler.watchFileSystem;
+			const mtimes: { [filePath: string]: number } = Object.create(null);
+			let watcher: any;
+
+			Object.defineProperty(wfs, 'watcher', {
+				get() {
+					return watcher;
+				},
+				set(_watcher) {
+					watcher = _watcher;
+					const onChange = watcher._onChange;
+					watcher._onChange = function (item: string, mtime: number) {
+						if (!(item in mtimes) || mtimes[item] !== mtime) {
+							mtimes[item] = mtime - FS_ACCURACY;
+							return onChange.apply(watcher, arguments);
+						}
+
+						delete mtimes[item];
+						watcher._onChange = onChange;
+					};
+				}
+			});
+		});
+	}
+}
+
+export default IgnoreUnmodifiedPlugin;

--- a/src/webpack.config.ts
+++ b/src/webpack.config.ts
@@ -105,6 +105,7 @@ function webpackConfig(args: Partial<BuildArgs>) {
 		plugins: [
 			new webpack.BannerPlugin(readFileSync(require.resolve(`${packagePath}/banner.md`), 'utf8')),
 			new IgnorePlugin(/request\/providers\/node/),
+			new webpack.WatchIgnorePlugin([ /\.css\.d\.ts$/ ]),
 			new NormalModuleReplacementPlugin(/\.m.css$/, result => {
 				const requestFileName = path.resolve(result.context, result.request);
 				const jsFileName = requestFileName + '.js';

--- a/src/webpack.config.ts
+++ b/src/webpack.config.ts
@@ -106,7 +106,6 @@ function webpackConfig(args: Partial<BuildArgs>) {
 		plugins: [
 			new webpack.BannerPlugin(readFileSync(require.resolve(`${packagePath}/banner.md`), 'utf8')),
 			new IgnorePlugin(/request\/providers\/node/),
-			new IgnoreUnmodifiedPlugin(),
 			new NormalModuleReplacementPlugin(/\.m.css$/, result => {
 				const requestFileName = path.resolve(result.context, result.request);
 				const jsFileName = requestFileName + '.js';
@@ -119,6 +118,9 @@ function webpackConfig(args: Partial<BuildArgs>) {
 				}
 			}),
 			new webpack.ContextReplacementPlugin(/dojo-app[\\\/]lib/, { test: () => false }),
+			...includeWhen(args.watch, () => {
+				return [ new IgnoreUnmodifiedPlugin() ];
+			}),
 			includeWhen(args.element, args => {
 				return new ExtractTextPlugin({ filename: `${args.elementPrefix}.css` });
 			}, () => {

--- a/src/webpack.config.ts
+++ b/src/webpack.config.ts
@@ -17,6 +17,7 @@ const isCLI = process.env.DOJO_CLI;
 const packagePath = isCLI ? '.' : '@dojo/cli-build-webpack';
 const CoreLoadPlugin = require(`${packagePath}/plugins/CoreLoadPlugin`).default;
 const I18nPlugin = require(`${packagePath}/plugins/I18nPlugin`).default;
+const IgnoreUnmodifiedPlugin = require(`${packagePath}/plugins/IgnoreUnmodifiedPlugin`).default;
 const basePath = process.cwd();
 
 let tslintExists = false;
@@ -105,7 +106,7 @@ function webpackConfig(args: Partial<BuildArgs>) {
 		plugins: [
 			new webpack.BannerPlugin(readFileSync(require.resolve(`${packagePath}/banner.md`), 'utf8')),
 			new IgnorePlugin(/request\/providers\/node/),
-			new webpack.WatchIgnorePlugin([ /\.css\.d\.ts$/ ]),
+			new IgnoreUnmodifiedPlugin(),
 			new NormalModuleReplacementPlugin(/\.m.css$/, result => {
 				const requestFileName = path.resolve(result.context, result.request);
 				const jsFileName = requestFileName + '.js';

--- a/src/webpack.d.ts
+++ b/src/webpack.d.ts
@@ -66,6 +66,7 @@ declare module 'webpack/lib/webpack' {
 	import WebpackNormalModuleReplacementPlugin = require('webpack/lib/NormalModuleReplacementPlugin');
 	import WebpackCommonsChunkPlugin = require('webpack/lib/optimize/CommonsChunkPlugin');
 	import WebpackUglifyJsPlugin = require('webpack/lib/optimize/UglifyJsPlugin');
+	import WebpackWatchIgnorePlugin = require('webpack/lib/WatchIgnorePlugin');
 
 	function webpack(options: webpack.Config, callback?: Function): WebpackCompiler;
 
@@ -74,10 +75,12 @@ declare module 'webpack/lib/webpack' {
 		export type Compiler = WebpackCompiler;
 		export type ContextReplacementPlugin = WebpackContextReplacementPlugin;
 		export type NormalModuleReplacementPlugin = WebpackNormalModuleReplacementPlugin;
+		export type WatchIgnorePlugin = WebpackWatchIgnorePlugin;
 		export const BannerPlugin: typeof WebpackBannerPlugin;
 		export const Compiler: typeof WebpackCompiler;
 		export const ContextReplacementPlugin: typeof WebpackContextReplacementPlugin;
 		export const NormalModuleReplacementPlugin: typeof WebpackNormalModuleReplacementPlugin;
+		export const WatchIgnorePlugin: typeof WebpackWatchIgnorePlugin;
 
 		namespace optimize {
 			type CommonsChunkPlugin = WebpackCommonsChunkPlugin;
@@ -657,6 +660,17 @@ declare module 'webpack/lib/Template' {
 	}
 
 	export = Template;
+}
+
+declare module 'webpack/lib/WatchIgnorePlugin' {
+	import webpack = require('webpack');
+
+	class WatchIgnorePlugin implements webpack.Plugin {
+		constructor(paths: Array<string | RegExp>);
+		apply(compiler: webpack.Compiler): void;
+	}
+
+	export = WatchIgnorePlugin;
 }
 
 declare module 'webpack/lib/optimize/CommonsChunkPlugin' {

--- a/src/webpack.d.ts
+++ b/src/webpack.d.ts
@@ -66,7 +66,6 @@ declare module 'webpack/lib/webpack' {
 	import WebpackNormalModuleReplacementPlugin = require('webpack/lib/NormalModuleReplacementPlugin');
 	import WebpackCommonsChunkPlugin = require('webpack/lib/optimize/CommonsChunkPlugin');
 	import WebpackUglifyJsPlugin = require('webpack/lib/optimize/UglifyJsPlugin');
-	import WebpackWatchIgnorePlugin = require('webpack/lib/WatchIgnorePlugin');
 
 	function webpack(options: webpack.Config, callback?: Function): WebpackCompiler;
 
@@ -75,12 +74,10 @@ declare module 'webpack/lib/webpack' {
 		export type Compiler = WebpackCompiler;
 		export type ContextReplacementPlugin = WebpackContextReplacementPlugin;
 		export type NormalModuleReplacementPlugin = WebpackNormalModuleReplacementPlugin;
-		export type WatchIgnorePlugin = WebpackWatchIgnorePlugin;
 		export const BannerPlugin: typeof WebpackBannerPlugin;
 		export const Compiler: typeof WebpackCompiler;
 		export const ContextReplacementPlugin: typeof WebpackContextReplacementPlugin;
 		export const NormalModuleReplacementPlugin: typeof WebpackNormalModuleReplacementPlugin;
-		export const WatchIgnorePlugin: typeof WebpackWatchIgnorePlugin;
 
 		namespace optimize {
 			type CommonsChunkPlugin = WebpackCommonsChunkPlugin;
@@ -378,6 +375,7 @@ declare module 'webpack/lib/Compiler' {
 
 	class Compiler extends Tapable {
 		options: any;
+		watchFileSystem: any;
 
 		run(callback: Compiler.Callback): void;
 		runAsChild(callback: Compiler.Callback): void;
@@ -396,6 +394,7 @@ declare module 'webpack/lib/Compiler' {
 		plugin(name: 'compile', fn: (this: Compiler, params: any) => void): void;
 		plugin(name: 'make', fn: (this: Compiler, compilation: Compilation) => void): void;
 		plugin(name: 'after-compile', fn: (this: Compiler, compilation: Compilation) => void): void;
+		plugin(name: 'after-environment', fn: (this: Compiler) => void): void;
 	}
 
 	namespace Compiler {
@@ -660,17 +659,6 @@ declare module 'webpack/lib/Template' {
 	}
 
 	export = Template;
-}
-
-declare module 'webpack/lib/WatchIgnorePlugin' {
-	import webpack = require('webpack');
-
-	class WatchIgnorePlugin implements webpack.Plugin {
-		constructor(paths: Array<string | RegExp>);
-		apply(compiler: webpack.Compiler): void;
-	}
-
-	export = WatchIgnorePlugin;
 }
 
 declare module 'webpack/lib/optimize/CommonsChunkPlugin' {

--- a/tests/support/webpack/Compiler.ts
+++ b/tests/support/webpack/Compiler.ts
@@ -7,6 +7,7 @@ import MockCompilationParams = require('./CompilationParams');
 class MockCompiler extends Pluginable {
 	applied: any[];
 	options: any;
+	watchFileSystem: any;
 
 	constructor(options?: any) {
 		super();
@@ -16,6 +17,7 @@ class MockCompiler extends Pluginable {
 				modules: [ '/root/path' ]
 			}
 		};
+		this.watchFileSystem = {};
 	}
 
 	apply(...args: any[]) {

--- a/tests/unit/all.ts
+++ b/tests/unit/all.ts
@@ -2,6 +2,7 @@ import './main';
 import './webpack.config';
 import './plugins/CoreLoadPlugin';
 import './plugins/I18nPlugin';
+import './plugins/IgnoreUnmodifiedPlugin';
 import './plugins/InjectModulesPlugin';
 import './plugins/util/i18n';
 import './plugins/util/main';

--- a/tests/unit/plugins/IgnoreUnmodifiedPlugin.ts
+++ b/tests/unit/plugins/IgnoreUnmodifiedPlugin.ts
@@ -1,0 +1,64 @@
+import { describe, it } from 'intern!bdd';
+import * as assert from 'intern/chai!assert';
+import * as sinon from 'sinon';
+import Compiler = require('../../support/webpack/Compiler');
+import IgnoreUnmodifiedPlugin from '../../../src/plugins/IgnoreUnmodifiedPlugin';
+
+const FILE_PATH = '/path/to/myWidget.m.css';
+const MTIME = 8675309;
+const FS_ACCURACY = 10000;
+
+function setup(useCustomWfs = false) {
+	const compiler = new Compiler();
+	const plugin = new IgnoreUnmodifiedPlugin();
+	const onChange = sinon.spy();
+
+	if (useCustomWfs) {
+		compiler.watchFileSystem.wfs = {};
+	}
+
+	plugin.apply(compiler);
+	compiler.mockApply('after-environment');
+
+	const watcher = { _onChange: onChange };
+	const wfs = useCustomWfs ? compiler.watchFileSystem.wfs : compiler.watchFileSystem;
+	wfs.watcher = watcher;
+
+	return { compiler, onChange, plugin, watcher };
+}
+
+describe('IgnoreUnmodifiedPlugin', () => {
+	it('should not emit change events when the mtime has not changed', () => {
+		const { compiler, onChange, watcher } = setup();
+
+		assert.strictEqual(compiler.watchFileSystem.watcher, watcher);
+
+		watcher._onChange(FILE_PATH, MTIME);
+		assert.isTrue(onChange.calledWith(FILE_PATH, MTIME));
+
+		watcher._onChange(FILE_PATH, MTIME - FS_ACCURACY);
+		assert.strictEqual(onChange.callCount, 1);
+
+		for (let i = 1; i <= 10; i++) {
+			watcher._onChange(FILE_PATH, MTIME + (FS_ACCURACY * i));
+			assert.strictEqual(onChange.callCount, i + 1);
+		}
+	});
+
+	it('should function identically when a custom file watcher is used', () => {
+		const { compiler, onChange, watcher } = setup(true);
+
+		assert.strictEqual(compiler.watchFileSystem.wfs.watcher, watcher);
+
+		watcher._onChange(FILE_PATH, MTIME);
+		assert.isTrue(onChange.calledWith(FILE_PATH, MTIME));
+
+		watcher._onChange(FILE_PATH, MTIME - FS_ACCURACY);
+		assert.strictEqual(onChange.callCount, 1);
+
+		for (let i = 1; i <= 10; i++) {
+			watcher._onChange(FILE_PATH, MTIME + (FS_ACCURACY * i));
+			assert.strictEqual(onChange.callCount, i + 1);
+		}
+	});
+});


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

The `css-module-dts-loader` creates new `d.ts` files for each CSS file, but each new `d.ts` triggers a compilation. This PR utilizes the `WatchIgnorePlugin` to prevent files ending in `.css.d.ts` from triggering builds. There may be a better way to solve this problem, but setting `watchOptions.ignored` or `exclude` on the relevant loaders has no effect. This fix has been verified using the reproduction steps listed in the issue.

Resolves #137 
