### PR TITLE
Service worker support

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "mockery": "^1.7.0",
     "remap-istanbul": "^0.6.4",
     "sinon": "^1.17.5",
-    "sw-precache-webpack-plugin": "^0.11.3",
     "yargs": "^5.0.0"
   },
   "dependencies": {
@@ -71,6 +70,7 @@
     "postcss-loader": "1.3.3",
     "source-map-loader-cli": "0.0.1",
     "style-loader": "0.13.2",
+    "sw-precache-webpack-plugin": "^0.11.3",
     "ts-loader": "2.3.1",
     "tslint": "4.5.1",
     "tslint-loader": "3.5.3",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "mockery": "^1.7.0",
     "remap-istanbul": "^0.6.4",
     "sinon": "^1.17.5",
+    "sw-precache-webpack-plugin": "^0.11.3",
     "yargs": "^5.0.0"
   },
   "dependencies": {

--- a/src/main.ts
+++ b/src/main.ts
@@ -23,7 +23,7 @@ export interface BuildArgs extends Argv {
 	withTests: boolean;
 	debug: boolean;
 	disableLazyWidgetDetection: boolean;
-	serviceWorkers: boolean;
+	serviceWorker: boolean;
 	bundles: Bundles;
 }
 
@@ -207,8 +207,8 @@ const command: Command = {
 			type: 'boolean'
 		});
 
-		options('serviceWorkers', {
-			describe: 'Enable use of ServiceWorkers, or AppCache as a fallback, to cache resources, allowing the project to work offline.',
+		options('serviceWorker', {
+			describe: 'Enable use of a Service Worker, if available, to cache resources, allowing the project to work offline.',
 			type: 'boolean'
 		});
 	},

--- a/src/main.ts
+++ b/src/main.ts
@@ -23,6 +23,7 @@ export interface BuildArgs extends Argv {
 	withTests: boolean;
 	debug: boolean;
 	disableLazyWidgetDetection: boolean;
+	serviceWorkers: boolean;
 	bundles: Bundles;
 }
 
@@ -203,6 +204,11 @@ const command: Command = {
 
 		options('disableLazyWidgetDetection', {
 			describe: 'Disable lazy widget loading detection',
+			type: 'boolean'
+		});
+
+		options('serviceWorkers', {
+			describe: 'Enable use of ServiceWorkers, or AppCache as a fallback, to cache resources, allowing the project to work offline.',
 			type: 'boolean'
 		});
 	},

--- a/src/main.ts
+++ b/src/main.ts
@@ -206,11 +206,6 @@ const command: Command = {
 			describe: 'Disable lazy widget loading detection',
 			type: 'boolean'
 		});
-
-		options('serviceWorker', {
-			describe: 'Enable use of a Service Worker, if available, to cache resources, allowing the project to work offline.',
-			type: 'boolean'
-		});
 	},
 	run(helper: Helper, args: BuildArgs): Promise<void> {
 		const dojoRc = helper.configuration.get() || Object.create(null);

--- a/src/webpack.config.ts
+++ b/src/webpack.config.ts
@@ -5,11 +5,13 @@ import { existsSync, readFileSync } from 'fs';
 import { BuildArgs } from './main';
 import Set from '@dojo/shim/Set';
 const IgnorePlugin = require('webpack/lib/IgnorePlugin');
+const DefinePlugin = require('webpack/lib/DefinePlugin');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const OptimizeCssAssetsPlugin = require('optimize-css-assets-webpack-plugin');
 const BundleAnalyzerPlugin = require('webpack-bundle-analyzer-sunburst').BundleAnalyzerPlugin;
+const SWPrecacheWebpackPlugin = require('sw-precache-webpack-plugin');
 const postcssImport = require('postcss-import');
 const postcssCssNext = require('postcss-cssnext');
 
@@ -116,6 +118,9 @@ function webpackConfig(args: Partial<BuildArgs>) {
 					result.request = result.request.replace(/\.m\.css$/, '.m.css.js');
 				}
 			}),
+			new DefinePlugin({
+				'process.env.DOJO_SERVICE_WORKERS': JSON.stringify(Boolean(args.serviceWorkers))
+			}),
 			new webpack.ContextReplacementPlugin(/dojo-app[\\\/]lib/, { test: () => false }),
 			includeWhen(args.element, args => {
 				return new ExtractTextPlugin({ filename: `${args.elementPrefix}.css` });
@@ -202,7 +207,8 @@ function webpackConfig(args: Partial<BuildArgs>) {
 						filename: '../_build/src/index.html'
 					})
 				];
-			})
+			}),
+			includeWhen(args.serviceWorkers, () => new SWPrecacheWebpackPlugin())
 		],
 		output: {
 			libraryTarget: 'umd',

--- a/src/webpack.config.ts
+++ b/src/webpack.config.ts
@@ -105,6 +105,9 @@ function webpackConfig(args: Partial<BuildArgs>) {
 			};
 		}),
 		plugins: [
+			...includeWhen(!args.watch && args.serviceWorker, () => [ new SWPrecacheWebpackPlugin({
+				minify: true
+			}) ]),
 			new webpack.BannerPlugin(readFileSync(require.resolve(`${packagePath}/banner.md`), 'utf8')),
 			new IgnorePlugin(/request\/providers\/node/),
 			new NormalModuleReplacementPlugin(/\.m.css$/, result => {
@@ -118,9 +121,6 @@ function webpackConfig(args: Partial<BuildArgs>) {
 					result.request = result.request.replace(/\.m\.css$/, '.m.css.js');
 				}
 			}),
-			...includeWhen(!args.watch && args.serviceWorker, () => [ new SWPrecacheWebpackPlugin({
-				minify: true
-			}) ]),
 			new DefinePlugin({
 				'process.env.DOJO_SERVICE_WORKERS': JSON.stringify(Boolean(!args.watch && args.serviceWorker))
 			}),

--- a/src/webpack.config.ts
+++ b/src/webpack.config.ts
@@ -107,7 +107,8 @@ function webpackConfig(args: Partial<BuildArgs>) {
 		}),
 		plugins: [
 			...includeWhen(includeServiceWorker, () => [ new SWPrecacheWebpackPlugin({
-				minify: true
+				minify: true,
+				staticFileGlobsIgnorePatterns: [ /\.map$/ ]
 			}) ]),
 			new webpack.BannerPlugin(readFileSync(require.resolve(`${packagePath}/banner.md`), 'utf8')),
 			new IgnorePlugin(/request\/providers\/node/),
@@ -123,7 +124,7 @@ function webpackConfig(args: Partial<BuildArgs>) {
 				}
 			}),
 			new DefinePlugin({
-				'process.env.DOJO_SERVICE_WORKERS': JSON.stringify(includeServiceWorker)
+				'process.env.DOJO.SERVICE_WORKERS': JSON.stringify(includeServiceWorker)
 			}),
 			new webpack.ContextReplacementPlugin(/dojo-app[\\\/]lib/, { test: () => false }),
 			includeWhen(args.element, args => {

--- a/src/webpack.config.ts
+++ b/src/webpack.config.ts
@@ -118,8 +118,11 @@ function webpackConfig(args: Partial<BuildArgs>) {
 					result.request = result.request.replace(/\.m\.css$/, '.m.css.js');
 				}
 			}),
+			...includeWhen(!args.watch && args.serviceWorker, () => [ new SWPrecacheWebpackPlugin({
+				minify: true
+			}) ]),
 			new DefinePlugin({
-				'process.env.DOJO_SERVICE_WORKERS': JSON.stringify(Boolean(args.serviceWorkers))
+				'process.env.DOJO_SERVICE_WORKERS': JSON.stringify(Boolean(!args.watch && args.serviceWorker))
 			}),
 			new webpack.ContextReplacementPlugin(/dojo-app[\\\/]lib/, { test: () => false }),
 			includeWhen(args.element, args => {
@@ -207,8 +210,7 @@ function webpackConfig(args: Partial<BuildArgs>) {
 						filename: '../_build/src/index.html'
 					})
 				];
-			}),
-			includeWhen(args.serviceWorkers, () => new SWPrecacheWebpackPlugin())
+			})
 		],
 		output: {
 			libraryTarget: 'umd',

--- a/src/webpack.config.ts
+++ b/src/webpack.config.ts
@@ -105,7 +105,7 @@ function webpackConfig(args: Partial<BuildArgs>) {
 			};
 		}),
 		plugins: [
-			...includeWhen(!args.watch && args.serviceWorker, () => [ new SWPrecacheWebpackPlugin({
+			...includeWhen(!args.watch && !args.withTests && args.serviceWorker, () => [ new SWPrecacheWebpackPlugin({
 				minify: true
 			}) ]),
 			new webpack.BannerPlugin(readFileSync(require.resolve(`${packagePath}/banner.md`), 'utf8')),

--- a/src/webpack.config.ts
+++ b/src/webpack.config.ts
@@ -34,6 +34,7 @@ function webpackConfig(args: Partial<BuildArgs>) {
 
 	const cssLoader = ExtractTextPlugin.extract({ use: 'css-loader?sourceMap' });
 	const localIdentName = (args.watch || args.withTests) ? '[name]__[local]__[hash:base64:5]' : '[hash:base64:8]';
+	const includeServiceWorker = Boolean(!args.withTests && !args.watch && args.serviceWorker);
 	const cssModuleLoader = ExtractTextPlugin.extract({
 		use: [
 			'css-module-decorator-loader',
@@ -105,7 +106,7 @@ function webpackConfig(args: Partial<BuildArgs>) {
 			};
 		}),
 		plugins: [
-			...includeWhen(!args.watch && !args.withTests && args.serviceWorker, () => [ new SWPrecacheWebpackPlugin({
+			...includeWhen(includeServiceWorker, () => [ new SWPrecacheWebpackPlugin({
 				minify: true
 			}) ]),
 			new webpack.BannerPlugin(readFileSync(require.resolve(`${packagePath}/banner.md`), 'utf8')),
@@ -122,7 +123,7 @@ function webpackConfig(args: Partial<BuildArgs>) {
 				}
 			}),
 			new DefinePlugin({
-				'process.env.DOJO_SERVICE_WORKERS': JSON.stringify(Boolean(!args.watch && args.serviceWorker))
+				'process.env.DOJO_SERVICE_WORKERS': JSON.stringify(includeServiceWorker)
 			}),
 			new webpack.ContextReplacementPlugin(/dojo-app[\\\/]lib/, { test: () => false }),
 			includeWhen(args.element, args => {

--- a/tests/unit/webpack.config.ts
+++ b/tests/unit/webpack.config.ts
@@ -20,10 +20,12 @@ function start(cli = true) {
 		'extract-text-webpack-plugin',
 		'html-webpack-plugin',
 		'optimize-css-assets-webpack-plugin',
+		'sw-precache-webpack-plugin',
 		'postcss-cssnext',
 		'postcss-import',
 		'webpack-bundle-analyzer-sunburst',
 		'webpack/lib/IgnorePlugin',
+		'webpack/lib/DefinePlugin',
 		'webpack'
 	]);
 	mockModule.start();


### PR DESCRIPTION
**Type:** bug / feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Relates to dojo/meta#169. Adds a flag `--serviceWorker`. If this flag is specified, and not running in watch mode or building tests, the `process.env.DOJO_SERVICE_WORKER` flag will be set to true, and the `sw-precache-webpack-plugin` will be enabled, adding support for caching all resources with a service worker to the app.  

The [hacker news PWA PR](https://github.com/dojo/examples/pull/227), which is still a WIP, if built with this branch will work offline. With this and the changes it depends on in `dojo/stores` for IndexedDB the entire app currently runs offline after the first load.