### PR TITLE
Adding check for port in use, issue #86

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,21 @@ You can also build in watch mode, which will automatically rebuild your applicat
 dojo build webpack -w
 ```
 
+When using watch mode, you can specify a port, or port range, to use when determining which port to serve your application on.
+
+```bash
+# a single port
+dojo build webpack -w --port=8080
+
+# a list of ports
+dojo build webpack -w --port=8080,8181
+
+# a range of ports
+dojo build webpack -w --port=9010:9000
+```
+
+The watch server will use the first unused port in the list you specified. Default port range is 9990-9999.
+
 `@dojo/cli-build-webpack` can be customized further. Use the help option to see everything you can do:
 
 ```bash

--- a/src/main.ts
+++ b/src/main.ts
@@ -100,7 +100,8 @@ async function isPortAvailable(port: number): Promise<boolean> {
 		server.once('error', function (err: any) {
 			if (err.code === 'EADDRINUSE') {
 				resolve(false);
-			} else {
+			}
+			else {
 				reject(new Error(`Unexpected error ${err.message}`));
 			}
 		});

--- a/tests/unit/main.ts
+++ b/tests/unit/main.ts
@@ -66,7 +66,7 @@ describe('main', () => {
 				},
 				listen() {
 					if (inUse) {
-						callbacks['error']({code: errorCode});
+						callbacks['error']({code: errorCode, message: 'test error'});
 					} else {
 						callbacks['listening']();
 					}
@@ -88,7 +88,7 @@ describe('main', () => {
 				},
 				listen(port: number) {
 					if (ports.find(p => p === port)) {
-						callbacks['error']({code: 'EADDRINUSE'});
+						callbacks['error']({code: 'EADDRINUSE', message: 'test error'});
 					} else {
 						callbacks['listening']();
 					}
@@ -204,7 +204,7 @@ describe('main', () => {
 		return moduleUnderTest.run(getMockConfiguration(), { watch: true }).then(
 			throwImmediately,
 			(e: Error) => {
-				assert.isTrue(e.message.indexOf('Unexpected error') >= 0);
+				assert.strictEqual(e.message, 'Unexpected error test error');
 			}
 		);
 	});


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Adding an error message if you try to start the dev server and the port is in use. Note that this is not specifically checking if the watch command is already running, just that the specified port is available.

Resolves #86 
