### PR TITLE
Fix formatting of externals config section of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,15 +95,14 @@ External libraries that cannot be loaded normally via webpack can be included in
 configuration in the project's `.dojorc` file.
 `.dojorc` is a JSON file that contains configuration for Dojo 2 CLI tasks. Configuration for the `dojo build` task can be provided under the
 `build-webpack` property.
-Configuration for external dependencies can be provided under the `externals` property of the `build-webpack` config.
+Configuration for external dependencies can be provided under the `externals` property of the `build-webpack` config. `externals` is an object with two
+allowed properties:
 
-`externals` is an object, with two allowed properties.
+* `outputPath`: An optional property specifying an output path to which files should be copied.
 
- `outputPath`: An optional property specifying an output path to which files should be copied.
-
- `dependencies`: A required array that defines which modules should be loaded via the external loader, and what files should be included in the build. Each entry can be one of two types:
-* A string. In this case the entry simply indicates that this path, and any children of this path, should be loaded via the external loader
-* An object that provides additional configuration for dependencies that need to be copied into the built application. This object has the following properties:
+* `dependencies`: A required array that defines which modules should be loaded via the external loader, and what files should be included in the build. Each entry can be one of two types:
+ * A string that indicates that this path, and any children of this path, should be loaded via the external loader
+ * An object that provides additional configuration for dependencies that need to be copied into the built application. This object has the following properties:
 
  | Property | Type | optional | Description |
  | -------- | ---- | -------- | ----------- |
@@ -112,8 +111,7 @@ Configuration for external dependencies can be provided under the `externals` pr
  | `name` | `string` | `true` | Indicates that this path, and any children of this path, should be loaded via the external loader |
  | `inject` | `string, string[], or boolean` | `true` | This property indicates that this dependency defines, or includes, scripts or stylesheets that should be loaded on the page. If `inject` is set to `true`, then the file at the location specified by `to` or `from` will be loaded on the page. If this dependency is a folder, then `inject` can be set to a string or array of strings to define one or more files to inject. Each path in `inject` should be relative to `${externalsOutputPath}/${to}` or `${externalsOutputPath}/${from}` depending on whether `to` was provided. |
 
- As an example the following configuration will inject `src/legacy/layer.js` into the application page, declare that modules `a`, `b`, and `c` are external
- and should be delegated to the external layer, and then copy the folder `node_modules/legacy-dep`, from which several files are injected. All of these files will be copied into the `externals` folder, which could be overridden by specifying the `outputPath` property in the `externals` configuration.
+As an example the following configuration will inject `src/legacy/layer.js` into the application page, declare that modules `a`, `b`, and `c` are external and should be delegated to the external layer, and then copy the folder `node_modules/legacy-dep`, from which several files are injected. All of these files will be copied into the `externals` folder, which could be overridden by specifying the `outputPath` property in the `externals` configuration.
  ```
  "externals": {
     "dependencies": [


### PR DESCRIPTION
**Type:** Formatting

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Fixes formatting of the `externals` documentation in the README.
