### PR TITLE
fix unescaped '.' in dts-loader regex

### DIFF
--- a/src/loaders/css-module-dts-loader/loader.ts
+++ b/src/loaders/css-module-dts-loader/loader.ts
@@ -47,7 +47,7 @@ function generateDTSFile(filePath: string): Promise<void> {
 function getCssImport(node: Node): string | void {
 	if (node.kind === SyntaxKind.StringLiteral) {
 		const importPath = node.getText().replace(/\'|\"/g, '');
-		if (/.css$/.test(importPath)) {
+		if (/\.css$/.test(importPath)) {
 			const parentFileName = node.getSourceFile().fileName;
 			return resolve(dirname(parentFileName), importPath);
 		}

--- a/tests/unit/loaders/css-module-dts-loader.ts
+++ b/tests/unit/loaders/css-module-dts-loader.ts
@@ -28,6 +28,7 @@ const tsContentWithMultipleCss = `
 const tsContentWithoutCss = `
 	import thing from 'place';
 	import this from 'that';
+	import other from 'somemoduleendingwithcss';
 `;
 
 describe('css-module-dts-loader', () => {


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

- fix unescaped regex
- modified the 'should not generate dts files if no css imports are found' test to catch the issue and to show that the fix works

Resolves #193 
