### PR TITLE
Add node webpack setting

### DIFF
--- a/src/webpack.config.ts
+++ b/src/webpack.config.ts
@@ -118,6 +118,12 @@ function webpackConfig(args: Partial<BuildArgs>) {
 				})
 			};
 		}),
+		node: {
+			dgram: 'empty',
+			net: 'empty',
+			tls: 'empty',
+			fs: 'empty'
+		},
 		plugins: [
 			new AutoRequireWebpackPlugin(/src\/main/),
 			new webpack.BannerPlugin(readFileSync(require.resolve(`${packagePath}/banner.md`), 'utf8')),

--- a/src/webpack.d.ts
+++ b/src/webpack.d.ts
@@ -99,13 +99,13 @@ declare module 'webpack/lib/webpack' {
 		}
 
 		interface Node {
-			console?: boolean;
+			console?: boolean | 'mock';
 			global?: boolean;
 			process?: boolean;
-			__filename?: boolean | 'empty' | 'mock' | undefined;
-			__dirname?: boolean | 'empty' | 'mock' | undefined;
-			Buffer?: boolean;
-			setImmediate?: boolean;
+			__filename?: boolean | 'mock';
+			__dirname?: boolean | 'mock';
+			Buffer?: boolean | 'mock';
+			setImmediate?: boolean | 'mock' | 'empty';
 			[moduleName: string]: boolean | 'empty' | 'mock' | undefined;
 		}
 
@@ -113,7 +113,7 @@ declare module 'webpack/lib/webpack' {
 			entry: string | string[] | { [key: string]: string | string[] };
 			output: Output;
 			module: Module;
-			node: Node;
+			node?: Node | false;
 			resolve?: Resolve;
 			resolveLoader?: {
 				modules?: string[];

--- a/src/webpack.d.ts
+++ b/src/webpack.d.ts
@@ -98,10 +98,22 @@ declare module 'webpack/lib/webpack' {
 			test?: Condition;
 		}
 
+		interface Node {
+			console?: boolean;
+			global?: boolean;
+			process?: boolean;
+			__filename?: boolean | 'empty' | 'mock' | undefined;
+			__dirname?: boolean | 'empty' | 'mock' | undefined;
+			Buffer?: boolean;
+			setImmediate?: boolean;
+			[moduleName: string]: boolean | 'empty' | 'mock' | undefined;
+		}
+
 		interface Config {
 			entry: string | string[] | { [key: string]: string | string[] };
 			output: Output;
 			module: Module;
+			node: Node;
 			resolve?: Resolve;
 			resolveLoader?: {
 				modules?: string[];


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

- add Node interface to webpack.d.ts
- add 'empty' node config for dgram, fs, net, and tls modules

Resolves #187 