### PR TITLE
Migrate to @dojo/interfaces/cli and @types

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "test": "grunt test"
   },
   "devDependencies": {
-    "@dojo/cli": "next",
     "@dojo/interfaces": "next",
     "@dojo/loader": "next",
     "@types/chai": "^3.4.34",
@@ -35,6 +34,7 @@
     "@types/node": "^6.0.49",
     "@types/sinon": "^1.16.32",
     "@types/source-map": "^0.5.0",
+    "@types/yargs": "^8.0.2",
     "cldr-data": "^30.0.1",
     "codecov.io": "0.1.6",
     "glob": "^7.0.3",

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,4 @@
 import { Command, EjectOutput, Helper, OptionsHelper } from '@dojo/interfaces/cli';
-import { Argv } from 'yargs';
 import * as fs from 'fs';
 import * as path from 'path';
 import { underline } from 'chalk';
@@ -13,7 +12,7 @@ export interface Bundles {
 	[key: string]: string[];
 }
 
-export interface BuildArgs extends Argv {
+export interface BuildArgs {
 	messageBundles: string | string[];
 	supportedLocales: string | string[];
 	watch: boolean;
@@ -154,7 +153,7 @@ function buildNpmDependencies(): any {
 	}
 }
 
-const command: Command = {
+const command: Command<BuildArgs> = {
 	description: 'create a build of your application',
 	register(options: OptionsHelper): void {
 		options('w', {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import { Command, EjectOutput, Helper, OptionsHelper } from '@dojo/cli/interfaces';
+import { Command, EjectOutput, Helper, OptionsHelper } from '@dojo/interfaces/cli';
 import { Argv } from 'yargs';
 import * as fs from 'fs';
 import * as path from 'path';
@@ -14,7 +14,6 @@ export interface Bundles {
 }
 
 export interface BuildArgs extends Argv {
-	locale: string;
 	messageBundles: string | string[];
 	supportedLocales: string | string[];
 	watch: boolean;
@@ -26,6 +25,7 @@ export interface BuildArgs extends Argv {
 	disableLazyWidgetDetection: boolean;
 	bundles: Bundles;
 	externals: { outputPath?: string; dependencies: ExternalDep[] };
+	[index: string]: any;
 }
 
 interface ConfigFactory {
@@ -41,7 +41,7 @@ interface WebpackOptions {
 }
 
 function getConfigArgs(args: BuildArgs): Partial<BuildArgs> {
-	const { locale, messageBundles, supportedLocales, watch } = args;
+	const { messageBundles, supportedLocales, watch } = args;
 	const options: Partial<BuildArgs> = Object.keys(args).reduce((options: Partial<BuildArgs>, key: string) => {
 		if (key !== 'messageBundles' && key !== 'supportedLocales') {
 			options[key] = args[key];

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,7 +25,6 @@
 		]
 	},
 	"include": [
-		"./typings/index.d.ts",
 		"./src/**/*.ts",
 		"./tests/**/*.ts"
 	]

--- a/typings.json
+++ b/typings.json
@@ -1,6 +1,0 @@
-{
-	"name": "dojo-cli-build",
-	"dependencies": {
-		"yargs": "registry:npm/yargs#5.0.0+20160817153026"
-	}
-}


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Migrate to use `@dojo/interfaces/cli` and `@types` for other typings.

Depends on a release of `@dojo/interfaces`.

Refs: https://github.com/dojo/cli/issues/119