### PR TITLE
Use the package name to set the jsonpFunction

### DIFF
--- a/src/webpack.config.ts
+++ b/src/webpack.config.ts
@@ -34,7 +34,7 @@ type IncludeCallback = (args: BuildArgs) => any;
 function getJsonpFunction(name?: string) {
 	let jsonpFunction = 'dojoWebpackJsonp';
 	if (name) {
-		jsonpFunction += '_' + name.replace(/[^a-z0-9_]/g, ' ').trim().replace(/\s/g, '_');
+		jsonpFunction += '_' + name.replace(/[^a-z0-9_]/g, ' ').trim().replace(/\s+/g, '_');
 	}
 	return jsonpFunction;
 }

--- a/src/webpack.config.ts
+++ b/src/webpack.config.ts
@@ -20,6 +20,9 @@ const I18nPlugin = require(`${packagePath}/plugins/I18nPlugin`).default;
 const IgnoreUnmodifiedPlugin = require(`${packagePath}/plugins/IgnoreUnmodifiedPlugin`).default;
 const basePath = process.cwd();
 
+const packageJsonPath = path.join(basePath, 'package.json');
+const packageJson = existsSync(packageJsonPath) ? require(packageJsonPath) : undefined;
+
 let tslintExists = false;
 try {
 	require(path.join(basePath, 'tslint'));
@@ -27,6 +30,14 @@ try {
 } catch (ignore) { }
 
 type IncludeCallback = (args: BuildArgs) => any;
+
+function getJsonpFunction(name?: string) {
+	let jsonpFunction = 'dojoWebpackJsonp';
+	if (name) {
+		jsonpFunction += '_' + name.replace(/[^a-z0-9_]/g, ' ').trim().replace(/\s/g, '_');
+	}
+	return jsonpFunction;
+}
 
 function webpackConfig(args: Partial<BuildArgs>) {
 	args = args || {};
@@ -233,6 +244,7 @@ function webpackConfig(args: Partial<BuildArgs>) {
 		output: {
 			libraryTarget: 'umd',
 			library: '[name]',
+			jsonpFunction: getJsonpFunction(packageJson && packageJson.name),
 			umdNamedDefine: true,
 			path: includeWhen(args.element, args => {
 				return path.resolve(`./dist/${args.elementPrefix}`);

--- a/tests/unit/webpack.config.ts
+++ b/tests/unit/webpack.config.ts
@@ -14,6 +14,13 @@ let mockModule: MockModule;
 let config: Config;
 
 function start(cli = true) {
+	const mockPackageJson = {
+		name: resolve(basePath, 'package.json'),
+		mock: {
+			name: '@namespace/package'
+		}
+	};
+
 	mockModule = new MockModule('../../src/webpack.config');
 	mockModule.dependencies([
 		'./plugins/CoreLoadPlugin',
@@ -27,7 +34,8 @@ function start(cli = true) {
 		'postcss-import',
 		'webpack-bundle-analyzer-sunburst',
 		'webpack/lib/IgnorePlugin',
-		'webpack'
+		'webpack',
+		mockPackageJson
 	]);
 	mockModule.start();
 
@@ -63,7 +71,7 @@ describe('webpack.config.ts', () => {
 		});
 
 		it('set the jsonFunction from the package name', () => {
-			assert.strictEqual(config.output.jsonpFunction, 'dojoWebpackJsonp_dojo_cli_build_webpack');
+			assert.strictEqual(config.output.jsonpFunction, 'dojoWebpackJsonp_namespace_package');
 		});
 	}
 

--- a/tests/unit/webpack.config.ts
+++ b/tests/unit/webpack.config.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, it } from 'intern!bdd';
 import * as assert from 'intern/chai!assert';
 import { resolve } from 'path';
 import { createContext, runInContext } from 'vm';
+import { Config } from 'webpack';
 import MockModule from '../support/MockModule';
 
 const basePath = process.cwd();
@@ -10,6 +11,7 @@ const configPath = resolve(basePath, '_build/src/webpack.config.js');
 const configString = readFileSync(configPath);
 const dirname = resolve(basePath, '_build/src');
 let mockModule: MockModule;
+let config: Config;
 
 function start(cli = true) {
 	mockModule = new MockModule('../../src/webpack.config');
@@ -43,10 +45,7 @@ function start(cli = true) {
 
 	const js = configString.toString('utf8').replace(/\$\{packagePath\}/g, dirname.replace(/\\/g, '/').replace(/^[cC]:/, ''));
 	runInContext(js, context);
-
-	if (cli) {
-		context.module.exports({});
-	}
+	config = cli ? context.module.exports({}) : context.module.exports;
 }
 
 describe('webpack.config.ts', () => {
@@ -61,6 +60,10 @@ describe('webpack.config.ts', () => {
 
 			const webpack = mockModule.getMock('webpack');
 			assert.isTrue(webpack.BannerPlugin.calledWith(expected));
+		});
+
+		it('set the jsonFunction from the package name', () => {
+			assert.strictEqual(config.output.jsonpFunction, 'dojoWebpackJsonp_dojo_cli_build_webpack');
 		});
 	}
 

--- a/tests/unit/webpack.config.ts
+++ b/tests/unit/webpack.config.ts
@@ -17,7 +17,7 @@ function start(cli = true) {
 	const mockPackageJson = {
 		name: resolve(basePath, 'package.json'),
 		mock: {
-			name: '@namespace/package'
+			name: '@namespace/complex$-package-name'
 		}
 	};
 
@@ -71,7 +71,7 @@ describe('webpack.config.ts', () => {
 		});
 
 		it('set the jsonFunction from the package name', () => {
-			assert.strictEqual(config.output.jsonpFunction, 'dojoWebpackJsonp_namespace_package');
+			assert.strictEqual(config.output.jsonpFunction, 'dojoWebpackJsonp_namespace_complex_package_name');
 		});
 	}
 


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Uses the `name` from package.json to generate a valid JavaScript function name to be used as the `output.jsonpFunction`, effectively preventing different builds from accidentally loading from the wrong bundle. The config uses simple character replacement to separate words with an underscore. For example `@dojo/cli-build-webpack` would become `dojoWebpackJsonp_cli_build_webpack`.

These changes were verified locally against an application containing multiple independent bundles.

Resolves #158
