### PR TITLE
Change output format for custom elements

### DIFF
--- a/src/webpack.config.ts
+++ b/src/webpack.config.ts
@@ -77,6 +77,14 @@ function webpackConfig(args: Partial<BuildArgs>) {
 		});
 	}
 
+	const outputConfig: webpack.Output = {
+		chunkFilename: '[name].js',
+		filename: '[name].js',
+		jsonpFunction: getJsonpFunction(packageJson && packageJson.name),
+		libraryTarget: 'umd',
+		path: path.resolve('./dist')
+	};
+
 	const config: webpack.Config = {
 		externals: [
 			function (context, request, callback) {
@@ -241,19 +249,17 @@ function webpackConfig(args: Partial<BuildArgs>) {
 			])
 
 		],
-		output: {
-			libraryTarget: 'umd',
-			library: '[name]',
-			jsonpFunction: getJsonpFunction(packageJson && packageJson.name),
-			umdNamedDefine: true,
-			path: includeWhen(args.element, args => {
-				return path.resolve(`./dist/${args.elementPrefix}`);
-			}, () => {
-				return path.resolve('./dist');
-			}),
-			filename: '[name].js',
-			chunkFilename: '[name].js'
-		},
+		output: includeWhen(args.element, args => {
+			return Object.assign(outputConfig, {
+				libraryTarget: 'jsonp',
+				path: path.resolve(`./dist/${args.elementPrefix}`)
+			});
+		}, () => {
+			return Object.assign(outputConfig, {
+				library: '[name]',
+				umdNamedDefine: true
+			});
+		}),
 		devtool: 'source-map',
 		resolve: {
 			modules: [


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Update the `output` configuration for custom element builds so that they are build with a jsonp wrapper, as opposed to a UMD wrapper, and also remove additional library-specific `output` configuration options. Changes have been verified locally with a test application that builds two separate custom elements.

Resolves #202 