### PR TITLE
Remove resolve-url-loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,6 @@
     "postcss-cssnext": "2.11.0",
     "postcss-import": "10.0.0",
     "postcss-loader": "2.0.6",
-    "resolve-url-loader": "2.1.0",
     "source-map-loader-cli": "0.0.1",
     "style-loader": "0.13.2",
     "ts-loader": "2.3.1",

--- a/src/webpack.config.ts
+++ b/src/webpack.config.ts
@@ -42,14 +42,14 @@ function getJsonpFunction(name?: string) {
 function webpackConfig(args: Partial<BuildArgs>) {
 	args = args || {};
 
-	const cssLoader = ExtractTextPlugin.extract({ use: 'css-loader?sourceMap!resolve-url-loader' });
+	const cssLoader = ExtractTextPlugin.extract({ use: 'css-loader?sourceMap' });
 	const localIdentName = (args.watch || args.withTests) ? '[name]__[local]__[hash:base64:5]' : '[hash:base64:8]';
 	const externalDependencies = args.externals && args.externals.dependencies;
 	const includesExternals = Boolean(externalDependencies && externalDependencies.length);
 	const cssModuleLoader = ExtractTextPlugin.extract({
 		use: [
 			'css-module-decorator-loader',
-			`css-loader?modules&sourceMap&importLoaders=1&localIdentName=${localIdentName}!resolve-url-loader`,
+			`css-loader?modules&sourceMap&importLoaders=1&localIdentName=${localIdentName}`,
 			{
 				loader: 'postcss-loader?sourceMap',
 				options: {


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Removes the `resolve-url-loader` from the Webpack configuration.

Resolves #204
