### PR TITLE
Compliation errors cause the build to fail now, dojo/cli-test-itern#31

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -35,7 +35,7 @@ export interface BuildArgs {
 	disableLazyWidgetDetection: boolean;
 	bundles: Bundles;
 	externals: { outputPath?: string; dependencies: ExternalDep[] };
-	features: string| string[];
+	features: string | string[];
 }
 
 interface ConfigFactory {
@@ -54,7 +54,7 @@ function getConfigArgs(args: BuildArgs): Partial<BuildArgs> {
 	const { messageBundles, supportedLocales, watch } = args;
 	const options: Partial<BuildArgs> = Object.keys(args).reduce((options: Partial<BuildArgs>, key: string) => {
 		if (key !== 'messageBundles' && key !== 'supportedLocales') {
-			options[ key ] = args[ key ];
+			options[key] = args[key];
 		}
 		return options;
 	}, Object.create(null));
@@ -86,9 +86,9 @@ function getConfigArgs(args: BuildArgs): Partial<BuildArgs> {
 function mergeConfigArgs(...sources: BuildArgs[]): BuildArgs {
 	return sources.reduce((args: BuildArgs, source: BuildArgs) => {
 		Object.keys(source).forEach((key: string) => {
-			const value = source[ key ];
+			const value = source[key];
 			if (typeof value !== 'undefined') {
-				args[ key ] = source[ key ];
+				args[key] = source[key];
 			}
 		});
 		return args;
@@ -123,9 +123,9 @@ async function watch(config: webpack.Config, options: WebpackOptions, args: Buil
 	config.entry = (function (entry) {
 		if (typeof entry === 'object' && !Array.isArray(entry)) {
 			Object.keys(entry).forEach((key) => {
-				const value = entry[ key ];
+				const value = entry[key];
 				if (typeof value === 'string') {
-					entry[ key ] = [ 'webpack-dev-server/client?', value ];
+					entry[key] = [ 'webpack-dev-server/client?', value ];
 				}
 				else {
 					value.unshift('webpack-dev-server/client?');

--- a/src/main.ts
+++ b/src/main.ts
@@ -35,7 +35,7 @@ export interface BuildArgs {
 	disableLazyWidgetDetection: boolean;
 	bundles: Bundles;
 	externals: { outputPath?: string; dependencies: ExternalDep[] };
-	features: string | string[];
+	features: string| string[];
 }
 
 interface ConfigFactory {
@@ -54,7 +54,7 @@ function getConfigArgs(args: BuildArgs): Partial<BuildArgs> {
 	const { messageBundles, supportedLocales, watch } = args;
 	const options: Partial<BuildArgs> = Object.keys(args).reduce((options: Partial<BuildArgs>, key: string) => {
 		if (key !== 'messageBundles' && key !== 'supportedLocales') {
-			options[key] = args[key];
+			options[ key ] = args[ key ];
 		}
 		return options;
 	}, Object.create(null));
@@ -73,7 +73,8 @@ function getConfigArgs(args: BuildArgs): Partial<BuildArgs> {
 
 		if (matches && matches[ 1 ]) {
 			options.elementPrefix = matches[ 1 ].replace(/[A-Z][a-z]/g, '-\$&').replace(/^-+/g, '').toLowerCase();
-		} else {
+		}
+		else {
 			console.error(`"${args.element}" does not follow the pattern "createXYZElement". Use --elementPrefix to name element.`);
 			process.exit();
 		}
@@ -85,9 +86,9 @@ function getConfigArgs(args: BuildArgs): Partial<BuildArgs> {
 function mergeConfigArgs(...sources: BuildArgs[]): BuildArgs {
 	return sources.reduce((args: BuildArgs, source: BuildArgs) => {
 		Object.keys(source).forEach((key: string) => {
-			const value = source[key];
+			const value = source[ key ];
 			if (typeof value !== 'undefined') {
-				args[key] = source[key];
+				args[ key ] = source[ key ];
 			}
 		});
 		return args;
@@ -122,9 +123,9 @@ async function watch(config: webpack.Config, options: WebpackOptions, args: Buil
 	config.entry = (function (entry) {
 		if (typeof entry === 'object' && !Array.isArray(entry)) {
 			Object.keys(entry).forEach((key) => {
-				const value = entry[key];
+				const value = entry[ key ];
 				if (typeof value === 'string') {
-					entry[key] = [ 'webpack-dev-server/client?', value ];
+					entry[ key ] = [ 'webpack-dev-server/client?', value ];
 				}
 				else {
 					value.unshift('webpack-dev-server/client?');
@@ -196,6 +197,14 @@ function compile(config: webpack.Config, options: WebpackOptions): Promise<void>
 				}
 
 				console.log(stats.toString(options.stats));
+
+				if (stats.compilation && stats.compilation.errors && stats.compilation.errors.length > 0) {
+					reject({
+						exitCode: 1,
+						message: ''
+					});
+					return;
+				}
 			}
 			resolve();
 		});

--- a/src/webpack.d.ts
+++ b/src/webpack.d.ts
@@ -374,6 +374,7 @@ declare module 'webpack/lib/Compilation' {
 		dependencyTemplates: Map<typeof Dependency, any>;
 		mainTemplate: MainTemplate;
 		moduleTemplate: ModuleTemplate;
+		errors?: Error[];
 
 		constructor(compiler: Compiler);
 
@@ -464,6 +465,7 @@ declare module 'webpack/lib/Compiler' {
 			hasWarnings(): boolean;
 			toJson(options?: webpack.Stats): {};
 			toString(options?: webpack.Stats): string;
+			compilation: Compilation;
 		}
 		class Watching {
 			close(callback: () => void): void;

--- a/tests/unit/main.ts
+++ b/tests/unit/main.ts
@@ -115,28 +115,28 @@ describe('main', () => {
 			[ 't', { alias: 'with-tests', describe: 'build tests as well as sources' } ]
 		);
 		assert.deepEqual(
-			options.args[ 3 ],
+			options.args[3],
 			[ 'locale', { describe: 'The default locale for the application', type: 'string' } ]
 		);
 		assert.deepEqual(
-			options.args[ 4 ],
+			options.args[4],
 			[ 'supportedLocales', { describe: 'Any additional locales supported by the application', type: 'array' } ]
 		);
 		assert.deepEqual(
-			options.args[ 5 ],
+			options.args[5],
 			[ 'messageBundles', { describe: 'Any message bundles to include in the build', type: 'array' } ]
 		);
 		assert.deepEqual(
-			options.args[ 6 ],
+			options.args[6],
 			[ 'element', { describe: 'Path to a custom element descriptor factory', type: 'string' } ]
 		);
 		assert.deepEqual(
-			options.args[ 7 ],
+			options.args[7],
 			[ 'elementPrefix', { describe: 'Output file for custom element', type: 'string' } ]
 		);
 
 		assert.deepEqual(
-			options.args[ 8 ],
+			options.args[8],
 			[ 'debug', { describe: 'Generate package information useful for debugging', type: 'boolean' } ]
 		);
 	});
@@ -199,7 +199,7 @@ describe('main', () => {
 			assert.isTrue(mockWebpackDevServer.listen.calledOnce);
 			assert.isTrue((<sinon.SinonStub> console.log).firstCall.calledWith('Starting server on http://localhost:9999'));
 			assert.equal(mockWebpackConfig.devtool, 'inline-source-map');
-			assert.equal(mockWebpackConfig.entry[ 'src/main' ][0], 'webpack-dev-server/client?');
+			assert.equal(mockWebpackConfig.entry['src/main'][0], 'webpack-dev-server/client?');
 		});
 	});
 

--- a/tests/unit/main.ts
+++ b/tests/unit/main.ts
@@ -20,7 +20,7 @@ describe('main', () => {
 			configuration: {
 				get() {
 					if (config) {
-						return config[ 'build-webpack' ];
+						return config['build-webpack'];
 					}
 				}
 			}
@@ -199,7 +199,7 @@ describe('main', () => {
 			assert.isTrue(mockWebpackDevServer.listen.calledOnce);
 			assert.isTrue((<sinon.SinonStub> console.log).firstCall.calledWith('Starting server on http://localhost:9999'));
 			assert.equal(mockWebpackConfig.devtool, 'inline-source-map');
-			assert.equal(mockWebpackConfig.entry[ 'src/main' ][ 0 ], 'webpack-dev-server/client?');
+			assert.equal(mockWebpackConfig.entry[ 'src/main' ][0], 'webpack-dev-server/client?');
 		});
 	});
 

--- a/tests/unit/main.ts
+++ b/tests/unit/main.ts
@@ -1,9 +1,9 @@
+import * as fs from 'fs';
 import { afterEach, beforeEach, describe, it } from 'intern!bdd';
 import * as assert from 'intern/chai!assert';
+import * as sinon from 'sinon';
 import MockModule from '../support/MockModule';
 import { throwImmediately } from '../support/util';
-import * as sinon from 'sinon';
-import * as fs from 'fs';
 
 describe('main', () => {
 
@@ -20,7 +20,7 @@ describe('main', () => {
 			configuration: {
 				get() {
 					if (config) {
-						return config['build-webpack'];
+						return config[ 'build-webpack' ];
 					}
 				}
 			}
@@ -108,31 +108,31 @@ describe('main', () => {
 		);
 		assert.deepEqual(
 			options.secondCall.args,
-			[ 'p', { alias: 'port', describe: 'port to serve on when using --watch. Can be a single port (9999), a range (9999:9990) or a list (9999,9997)', type: 'string' }]
+			[ 'p', { alias: 'port', describe: 'port to serve on when using --watch. Can be a single port (9999), a range (9999:9990) or a list (9999,9997)', type: 'string' } ]
 		);
 		assert.deepEqual(
 			options.thirdCall.args,
-			[ 't', { alias: 'with-tests', describe: 'build tests as well as sources' }]
+			[ 't', { alias: 'with-tests', describe: 'build tests as well as sources' } ]
 		);
 		assert.deepEqual(
-			options.args[3],
-			[ 'locale', { describe: 'The default locale for the application', type: 'string' }]
+			options.args[ 3 ],
+			[ 'locale', { describe: 'The default locale for the application', type: 'string' } ]
 		);
 		assert.deepEqual(
-			options.args[4],
-			[ 'supportedLocales', { describe: 'Any additional locales supported by the application', type: 'array' }]
+			options.args[ 4 ],
+			[ 'supportedLocales', { describe: 'Any additional locales supported by the application', type: 'array' } ]
 		);
 		assert.deepEqual(
-			options.args[5],
-			[ 'messageBundles', { describe: 'Any message bundles to include in the build', type: 'array' }]
+			options.args[ 5 ],
+			[ 'messageBundles', { describe: 'Any message bundles to include in the build', type: 'array' } ]
 		);
 		assert.deepEqual(
-			options.args[6],
-			[ 'element', { describe: 'Path to a custom element descriptor factory', type: 'string' }]
+			options.args[ 6 ],
+			[ 'element', { describe: 'Path to a custom element descriptor factory', type: 'string' } ]
 		);
 		assert.deepEqual(
-			options.args[7],
-			[ 'elementPrefix', { describe: 'Output file for custom element', type: 'string' }]
+			options.args[ 7 ],
+			[ 'elementPrefix', { describe: 'Output file for custom element', type: 'string' } ]
 		);
 
 		assert.deepEqual(
@@ -145,6 +145,24 @@ describe('main', () => {
 		const run = sandbox.stub().yields(false, 'some stats');
 		mockWebpack.returns({ run });
 		return moduleUnderTest.run(getMockConfiguration(), {}).then(() => {
+			assert.isTrue(run.calledOnce);
+			assert.isTrue((<sinon.SinonStub> console.log).calledWith('some stats'));
+		});
+	});
+
+	it('should run compile and log results on failure, but reject the promise', () => {
+		const run = sandbox.stub().yields(false, {
+			toString() {
+				return 'some stats';
+			},
+			compilation: {
+				errors: [ 'some error' ]
+			}
+		});
+		mockWebpack.returns({ run });
+		return moduleUnderTest.run(getMockConfiguration(), {}).then(() => {
+			throw new Error('shouldnt have succeeded');
+		}, () => {
 			assert.isTrue(run.calledOnce);
 			assert.isTrue((<sinon.SinonStub> console.log).calledWith('some stats'));
 		});
@@ -181,7 +199,7 @@ describe('main', () => {
 			assert.isTrue(mockWebpackDevServer.listen.calledOnce);
 			assert.isTrue((<sinon.SinonStub> console.log).firstCall.calledWith('Starting server on http://localhost:9999'));
 			assert.equal(mockWebpackConfig.devtool, 'inline-source-map');
-			assert.equal(mockWebpackConfig.entry['src/main'][0], 'webpack-dev-server/client?');
+			assert.equal(mockWebpackConfig.entry[ 'src/main' ][ 0 ], 'webpack-dev-server/client?');
 		});
 	});
 

--- a/tests/unit/main.ts
+++ b/tests/unit/main.ts
@@ -102,43 +102,25 @@ describe('main', () => {
 	it('should register supported arguments', () => {
 		const options = sandbox.stub();
 		moduleUnderTest.register(options);
-		assert.deepEqual(
-			options.firstCall.args,
-			[ 'w', { alias: 'watch', describe: 'watch and serve' } ]
-		);
-		assert.deepEqual(
-			options.secondCall.args,
-			[ 'p', { alias: 'port', describe: 'port to serve on when using --watch. Can be a single port (9999), a range (9999:9990) or a list (9999,9997)', type: 'string' } ]
-		);
-		assert.deepEqual(
-			options.thirdCall.args,
-			[ 't', { alias: 'with-tests', describe: 'build tests as well as sources' } ]
-		);
-		assert.deepEqual(
-			options.args[3],
-			[ 'locale', { describe: 'The default locale for the application', type: 'string' } ]
-		);
-		assert.deepEqual(
-			options.args[4],
-			[ 'supportedLocales', { describe: 'Any additional locales supported by the application', type: 'array' } ]
-		);
-		assert.deepEqual(
-			options.args[5],
-			[ 'messageBundles', { describe: 'Any message bundles to include in the build', type: 'array' } ]
-		);
-		assert.deepEqual(
-			options.args[6],
-			[ 'element', { describe: 'Path to a custom element descriptor factory', type: 'string' } ]
-		);
-		assert.deepEqual(
-			options.args[7],
-			[ 'elementPrefix', { describe: 'Output file for custom element', type: 'string' } ]
-		);
 
-		assert.deepEqual(
-			options.args[8],
-			[ 'debug', { describe: 'Generate package information useful for debugging', type: 'boolean' } ]
-		);
+		function assureArgument(arg: string) {
+			const supportedArgs = options.args.filter((args) => {
+				return args[ 0 ] === arg;
+			});
+
+			assert.lengthOf(supportedArgs, 1);
+		}
+
+		assureArgument('w');
+		assureArgument('p');
+		assureArgument('t');
+		assureArgument('locale');
+		assureArgument('supportedLocales');
+		assureArgument('messageBundles');
+		assureArgument('element');
+		assureArgument('elementPrefix');
+		assureArgument('debug');
+		assureArgument('force');
 	});
 
 	it('should run compile and log results on success', () => {


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Errors during the webpack build will now return a rejected promise. With this, `dojo test` will fail when you have build errors.

Resolves https://github.com/dojo/cli-test-intern/issues/31
