### PR TITLE
Failing on lint errors when doing a regular build

### DIFF
--- a/src/webpack.config.ts
+++ b/src/webpack.config.ts
@@ -1,11 +1,12 @@
 import webpack = require('webpack');
 import NormalModuleReplacementPlugin = require('webpack/lib/NormalModuleReplacementPlugin');
-import * as path from 'path';
-import { existsSync, readFileSync } from 'fs';
-import { BuildArgs } from './main';
 import Set from '@dojo/shim/Set';
 import StaticOptmizePlugin from '@dojo/static-optimize-plugin/StaticOptimizePlugin';
+import { existsSync, readFileSync } from 'fs';
+import * as path from 'path';
 import GetFeaturesType from './getFeatures';
+import { BuildArgs } from './main';
+
 const IgnorePlugin = require('webpack/lib/IgnorePlugin');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
@@ -289,7 +290,13 @@ function webpackConfig(args: Partial<BuildArgs>) {
 							enforce: 'pre',
 							loader: 'tslint-loader',
 							options: {
-								tsConfigFile: path.join(basePath, 'tslint.json')
+								tsConfigFile: path.join(basePath, 'tslint.json'),
+								...includeWhen(!args.watch && !args.withTests, () => {
+									return {
+										emitErrors: true,
+										failOnHint: true
+									};
+								})
 							}
 						}
 					];

--- a/tests/unit/webpack.config.ts
+++ b/tests/unit/webpack.config.ts
@@ -137,8 +137,8 @@ describe('webpack.config.ts', () => {
 			start(true, {});
 			const loader = getTslintLoader();
 			assert.isDefined(loader);
-			assert.strictEqual((<any> loader.options).emitErrors, true);
-			assert.strictEqual((<any> loader.options).failOnHint, true);
+			assert.isTrue((<any> loader.options).emitErrors);
+			assert.isTrue((<any> loader.options).failOnHint);
 		});
 
 		it('will not cause build errors on linting warnings if watching', () => {

--- a/tests/unit/webpack.config.ts
+++ b/tests/unit/webpack.config.ts
@@ -125,4 +125,36 @@ describe('webpack.config.ts', () => {
 			});
 		});
 	});
+
+	describe('tslint', () => {
+		function getTslintLoader() {
+			const tsLintLoaders = config.module.rules.filter((rule) => rule.loader === 'tslint-loader');
+
+			return tsLintLoaders[0];
+		}
+
+		it('will cause build errors on linting warnings if not watching or testing', () => {
+			start(true, {});
+			const loader = getTslintLoader();
+			assert.isDefined(loader);
+			assert.strictEqual((<any> loader.options).emitErrors, true);
+			assert.strictEqual((<any> loader.options).failOnHint, true);
+		});
+
+		it('will not cause build errors on linting warnings if watching', () => {
+			start(true, { watch: true });
+			const loader = getTslintLoader();
+			assert.isDefined(loader);
+			assert.isUndefined((<any> loader.options).emitErrors);
+			assert.isUndefined((<any> loader.options).failOnHint);
+		});
+
+		it('will not cause build errors on linting warnings if testing', () => {
+			start(true, { withTests: true });
+			const loader = getTslintLoader();
+			assert.isDefined(loader);
+			assert.isUndefined((<any> loader.options).emitErrors);
+			assert.isUndefined((<any> loader.options).failOnHint);
+		});
+	});
 });


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

This PR will make the webpack build fail (right away) if there are tslint problems when doing a regular (`dojo build`) build. If you use watch (`-w`) or tests (`-t`) the lint errors will only generate warnings.

Resolves #207 
