### PR TITLE
Add imports() support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@
 .tscache
 coverage-unmapped.json
 npm-debug.log
+/coverage
+coverage-final.lcov

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "postcss-cssnext": "2.11.0",
     "postcss-import": "10.0.0",
     "postcss-loader": "2.0.6",
+    "promise-loader": "^1.0.0",
     "source-map-loader-cli": "0.0.1",
     "style-loader": "0.13.2",
     "ts-loader": "2.3.1",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "tslint-loader": "3.5.3",
     "typed-css-modules": "0.2.0",
     "typescript": "2.4.2",
-    "umd-compat-loader": "2.1.0",
+    "umd-compat-loader": "2.1.1",
     "webpack": "2.7.0",
     "webpack-bundle-analyzer-sunburst": "1.2.0",
     "webpack-dev-server": "2.6.1"

--- a/tests/intern.ts
+++ b/tests/intern.ts
@@ -1,3 +1,5 @@
+process.env.DOJO_CLI = true;
+
 export const capabilities = {
 	'project': 'Dojo 2',
 	'name': '@dojo/cli-build-webpack'


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**
This adds support for using `import()` over `@dojo/core/load` in projects. It supports automatic lazy widget bundling, as well as bundles defined in the `.dojorc` like the existing functionality via `@dojo/core/load`.

This will mean users can now do:
```
registry.define('my-widget', async function () {
	const Module = await import('./MyWidget');
	return Module.default;
});
```
over:
```
registry.define('my-widget', async function () {
	const Module = await load(require, '/MyWidget');
	return Module.default;
});
```

Although this doesn't change much to an end user, we are at least using a standard, and it will eventually mean we can remove a fair amount of code from `cli-build` (https://github.com/dojo/cli-build-webpack/pull/89, https://github.com/dojo/cli-build-webpack/pull/92)