### PR TITLE
Fix assumptions about path separator

### DIFF
--- a/src/plugins/CoreLoadPlugin.ts
+++ b/src/plugins/CoreLoadPlugin.ts
@@ -57,7 +57,7 @@ function isContextual(module: NormalModule, issuers: string[]): boolean {
  * @return The normalized file path.
  */
 function normalizeFilePath(path: string): string {
-	return path.replace(/\\/g, '/').replace(/^[cC]:/, '');
+	return path.replace(/\\/g, '/').replace(/^[a-z]:/i, '');
 }
 
 /**

--- a/src/plugins/CoreLoadPlugin.ts
+++ b/src/plugins/CoreLoadPlugin.ts
@@ -1,5 +1,5 @@
 import * as path from 'path';
-import { getBasePath, resolveMid } from './util/main';
+import { createFilePathRegExp, getBasePath, resolveMid } from './util/main';
 import { CallExpression, Node, Program } from 'estree';
 import { getNextItem } from './util/parser';
 import Set from '@dojo/shim/Set';
@@ -25,6 +25,12 @@ const jsMidPattern = /\.(t|j)sx?$/;
 
 /**
  * @private
+ * Regular expression that matches a relative path, regardless of the file separator.
+ */
+const relativePathPattern = createFilePathRegExp('^\\.(\\.*)\/');
+
+/**
+ * @private
  * Test whether a module was required with a relative mid and is relative to a module with a contextual require.
  *
  * @param module
@@ -38,15 +44,26 @@ const jsMidPattern = /\.(t|j)sx?$/;
  */
 function isContextual(module: NormalModule, issuers: string[]): boolean {
 	const { rawRequest, userRequest } = module;
-	const relative = /^\.(\.*)\//;
 	const request = userRequest.replace(/\.[a-z0-9]+$/i, '');
-	return relative.test(rawRequest) && issuers.some((issuer: string) => path.resolve(issuer, rawRequest) === path.resolve(request));
+	return relativePathPattern.test(rawRequest) && issuers.some((issuer: string) => path.resolve(issuer, rawRequest) === path.resolve(request));
+}
+
+/**
+ * @private
+ * Strips the drive prefix from a file path and normalizes the path separator to '/'.
+ *
+ * @param path The path on which to operate.
+ *
+ * @return The normalized file path.
+ */
+function normalizeFilePath(path: string): string {
+	return path.replace(/\\/g, '/').replace(/^[cC]:/, '');
 }
 
 /**
  * @private
  * Remove the specified base path from the specified path. If the path begins with the base path, then also remove
- * the node_modules path segment.
+ * the node_modules path segment. Note that the file separator of the returned path is converted to '/'.
  *
  * @param basePath
  * The base path.
@@ -58,6 +75,8 @@ function isContextual(module: NormalModule, issuers: string[]): boolean {
  * The updated path.
  */
 function stripPath(basePath: string, path: string): string {
+	basePath = normalizeFilePath(basePath);
+	path = normalizeFilePath(path);
 	let resolved = (basePath ? path.replace(basePath + '/', '') : path).replace(/\..*$/, '');
 
 	if (path.indexOf(basePath) === 0) {
@@ -140,7 +159,7 @@ export default class DojoLoadPlugin {
 	constructor(options: DojoLoadPluginOptions = {}) {
 		const { basePath = './', chunkNames = {}, detectLazyLoads = false, ignoredModules, mapAppModules = false } = options;
 
-		this._basePath = basePath.replace(/\\/g, '/').replace(/^[cC]:/, '');
+		this._basePath = normalizeFilePath(basePath);
 		this._detectLazyLoads = detectLazyLoads;
 		this._lazyChunkNames = chunkNames;
 		this._mapAppModules = mapAppModules;
@@ -170,8 +189,9 @@ export default class DojoLoadPlugin {
 		const detectLazyLoads = this._detectLazyLoads;
 		const chunkNames = this._lazyChunkNames;
 		const ignoredModules = this._ignoredModules;
+		const coreLoadPattern = createFilePathRegExp('@dojo/core/load\\.js');
 
-		compiler.apply(new NormalModuleReplacementPlugin(/@dojo\/core\/load\.js/, resolveMid('@dojo/core/load/webpack')));
+		compiler.apply(new NormalModuleReplacementPlugin(coreLoadPattern, resolveMid('@dojo/core/load/webpack')));
 
 		compiler.plugin('compilation', (compilation, params) => {
 			params.normalModuleFactory.plugin('parser', function (parser) {
@@ -339,9 +359,12 @@ export default class DojoLoadPlugin {
 				}
 
 				modules.forEach(module => {
-					const { rawRequest, userRequest } = module;
+					let { rawRequest, userRequest } = module;
 
 					if (rawRequest) {
+						rawRequest = normalizeFilePath(rawRequest);
+						userRequest = normalizeFilePath(userRequest);
+
 						if (this._mapAppModules && path.resolve(userRequest).indexOf(path.resolve(appPath)) === 0) {
 							if (jsMidPattern.test(userRequest)) {
 								let modulePath = userRequest.replace(`${this._basePath}/`, '').replace(jsMidPattern, '');

--- a/src/plugins/util/main.ts
+++ b/src/plugins/util/main.ts
@@ -1,3 +1,17 @@
+const { normalize, sep } = require('path');
+const currentDirectoryPattern = createFilePathRegExp('^\\.\/');
+
+/**
+ * Creates a regular expression from a string that can match a file path regardless of the path separator.
+ *
+ * @param pattern A regular expression string that matches a file path pattern.
+ *
+ * @return A regular expression that matches a file path pattern.
+ */
+export function createFilePathRegExp(pattern: string): RegExp {
+	return new RegExp(pattern.replace(/\//g, '(\\\\|\/)'));
+}
+
 /**
  * Strips the module name from the provided path.
  *
@@ -8,8 +22,9 @@
  * The base path.
  */
 export function getBasePath(context: string): string {
-	const base = context.split('/').slice(0, -1).join('/');
-	return base === '' ? '/' : base;
+	const prefix = currentDirectoryPattern.test(context) ? `.${sep}` : '';
+	const base = normalize(context).split(sep).slice(0, -1).join(sep);
+	return base === '' ? sep : prefix + base;
 }
 
 const extensionPattern = /\.[a-z0-9]+$/i;
@@ -21,7 +36,7 @@ const extensionPattern = /\.[a-z0-9]+$/i;
  * The file path to test.
  *
  * @return
- * `true` if the file path has an extension; false otherwise.
+ * `true` if the file path has an extension; `false` otherwise.
  */
 export function hasExtension(path: string): boolean {
 	return extensionPattern.test(path);
@@ -58,8 +73,8 @@ export function mergeUnique(left: string[], right: string[]): string[] {
  * `true` if the path is relative; `false` otherwise.
  */
 export function isRelative(id: string): boolean {
-	const first = id.charAt(0);
-	return first !== '/' && first !== '@' && /^\W/.test(id);
+	const first = normalize(id.charAt(0));
+	return first !== sep && first !== '@' && /^\W/.test(id);
 }
 
 /**

--- a/src/webpack.config.ts
+++ b/src/webpack.config.ts
@@ -58,7 +58,8 @@ function getUMDCompatLoader(options: UMDCompatOptions) {
 				const filePath = path.relative(basePath, path.join(context, module));
 				let chunkName = filePath;
 				Object.keys(bundles).some((name) => {
-					if (bundles[name].indexOf(filePath) > -1) {
+					const bundlePaths = bundles[name].map(bundlePath => path.normalize(bundlePath));
+					if (bundlePaths.indexOf(filePath) > -1) {
 						chunkName = name;
 						return true;
 					}

--- a/tests/unit/plugins/CoreLoadPlugin.ts
+++ b/tests/unit/plugins/CoreLoadPlugin.ts
@@ -87,7 +87,7 @@ describe('core-load', () => {
 		plugin.apply(compiler);
 		const replacementPlugin = compiler.applied[0];
 		assert.instanceOf(replacementPlugin, NormalModuleReplacementPlugin);
-		assert.strictEqual(replacementPlugin.resourceRegExp.toString(), '/@dojo\\/core\\/load\\.js/');
+		assert.strictEqual(replacementPlugin.resourceRegExp.toString(), '/@dojo(\\\\|\\/)core(\\\\|\\/)load\\.js/');
 		assert.strictEqual(replacementPlugin.newResource, resolveMid('@dojo/core/load/webpack'));
 	});
 

--- a/tests/unit/plugins/I18nPlugin.ts
+++ b/tests/unit/plugins/I18nPlugin.ts
@@ -2,7 +2,7 @@ import { Program } from 'estree';
 import { beforeEach } from 'intern/lib/interfaces/tdd';
 import { sep as separator } from 'path';
 import I18nPlugin from '../../../src/plugins/I18nPlugin';
-import { hasExtension } from '../../../src/plugins/util/main';
+import { hasExtension, resolveMid } from '../../../src/plugins/util/main';
 import MockModule from '../../support/MockModule';
 import MockPlugin from '../../support/MockPlugin';
 import { fetchCldrData } from '../../support/util';
@@ -113,8 +113,8 @@ describe('i18n', () => {
 
 		const replacementPlugin = compiler.applied[0];
 		assert.instanceOf(replacementPlugin, NormalModuleReplacementPlugin);
-		assert.strictEqual(replacementPlugin.resourceRegExp.toString(), '/\\/cldr\\/load$/');
-		assert.strictEqual(replacementPlugin.newResource, '@dojo/i18n/cldr/load/webpack');
+		assert.strictEqual(replacementPlugin.resourceRegExp.toString(), '/(\\\\|\\/)cldr(\\\\|\\/)load($|\\.js)/');
+		assert.strictEqual(replacementPlugin.newResource, resolveMid('@dojo/i18n/cldr/load/webpack'));
 	});
 
 	describe('CLDR data', () => {
@@ -309,7 +309,8 @@ describe('i18n', () => {
 			const messagePlugins = MockPlugin.instances();
 			const main = messagePlugins[0];
 
-			assert.strictEqual(main.options.resourcePattern.toString(), new RegExp('tests/support/mocks/nls/main').toString());
+			const expectedPattern = new RegExp([ 'tests', 'support', 'mocks', 'nls', 'main' ].join('(\\\\|\\/)'));
+			assert.strictEqual(main.options.resourcePattern.toString(), expectedPattern.toString());
 			assert.sameMembers(
 				main.options.moduleIds,
 				locales.map((locale: string) => `tests/support/mocks/nls/${locale}/main`.replace(/\//g, separator))
@@ -342,7 +343,8 @@ describe('i18n', () => {
 			const messagePlugins = MockPlugin.instances();
 			const main = messagePlugins[0];
 
-			assert.strictEqual(main.options.resourcePattern.toString(), new RegExp('tests/support/mocks/nls/main.ts').toString());
+			const expectedPattern = new RegExp([ 'tests', 'support', 'mocks', 'nls', 'main.ts' ].join('(\\\\|\\/)'));
+			assert.strictEqual(main.options.resourcePattern.toString(), expectedPattern.toString());
 			assert.sameMembers(
 				main.options.moduleIds,
 				locales.map((locale: string) => `tests/support/mocks/nls/${locale}/main.ts`.replace(/\//g, separator))

--- a/tests/unit/plugins/InjectModulesPlugin.ts
+++ b/tests/unit/plugins/InjectModulesPlugin.ts
@@ -95,7 +95,7 @@ describe('inject-modules', () => {
 				.then((result: any[]) => {
 					assert.sameDeepMembers(result, [ data ]);
 					assert.deepEqual(input, {
-						context: '/parent',
+						context: `${path.sep}parent`,
 						contextInfo: {},
 						request: './module'
 					}, 'The context is issuer.');
@@ -109,7 +109,7 @@ describe('inject-modules', () => {
 				.then((result: any[]) => {
 					assert.sameDeepMembers(result, [ data ]);
 					assert.deepEqual(input, {
-						context: '/parent',
+						context: `${path.sep}parent`,
 						contextInfo: {},
 						request: './module'
 					}, 'The context is issuer even when a context for the module is provided.');
@@ -379,7 +379,7 @@ describe('inject-modules', () => {
 				resolver({ resource: '/test/module.js' }, () => {
 					try {
 						assert.isTrue((<any> plugin.resolve).called, 'was called');
-						assert.isTrue((<any> plugin.createModules).calledWith([ { contextInfo: {}, context: '/test', request: './module' } ]), 'was called with the right parameters');
+						assert.isTrue((<any> plugin.createModules).calledWith([ { contextInfo: {}, context: `${path.sep}test`, request: './module' } ]), 'was called with the right parameters');
 						resolve();
 					}
 					catch (error) {

--- a/tests/unit/plugins/util/i18n.ts
+++ b/tests/unit/plugins/util/i18n.ts
@@ -1,5 +1,5 @@
 import { Require } from '@dojo/interfaces/loader';
-import * as path from 'path';
+import { resolve, sep } from 'path';
 import getCldrUrls, { getLoadCallUrls, getLoadImports } from '../../../../src/plugins/util/i18n';
 import { Program } from 'estree';
 
@@ -52,7 +52,7 @@ describe('plugins/util/i18n', () => {
 
 		it('should resolve relative urls', () => {
 			assert.sameMembers(getCldrUrls('/parent/context/mid.ts', loadAst(false)), [
-				path.resolve('/parent/path/to/cldr/data.json')
+				resolve('/parent/path/to/cldr/data.json'.replace(/\//g, sep))
 			]);
 		});
 	});

--- a/tests/unit/plugins/util/main.ts
+++ b/tests/unit/plugins/util/main.ts
@@ -1,17 +1,27 @@
-import { getBasePath, hasExtension, isRelative, mergeUnique } from '../../../../src/plugins/util/main';
+import { sep } from 'path';
+import { createFilePathRegExp, getBasePath, hasExtension, isRelative, mergeUnique } from '../../../../src/plugins/util/main';
 
 const { assert } = intern.getPlugin('chai');
 const { describe, it } = intern.getInterface('bdd');
 
 describe('plugins/util/main', () => {
+	describe('createFilePathRegExp', () => {
+		it('should create a regular expression that can match either file separator', () => {
+			assert.instanceOf(createFilePathRegExp('/module'), RegExp);
+			assert.strictEqual(createFilePathRegExp('/module').toString(), '/(\\\\|\\/)module/');
+			assert.strictEqual(createFilePathRegExp('/module\\.ts').toString(), '/(\\\\|\\/)module\\.ts/');
+			assert.strictEqual(createFilePathRegExp('\\./parent/module\\.ts').toString(), '/\\.(\\\\|\\/)parent(\\\\|\\/)module\\.ts/');
+		});
+	});
+
 	describe('getBasePath', () => {
 		it('should strip the module name and return the parent path', () => {
-			assert.strictEqual(getBasePath('/module'), '/');
-			assert.strictEqual(getBasePath('/module.ts'), '/');
-			assert.strictEqual(getBasePath('./parent/module'), './parent');
-			assert.strictEqual(getBasePath('./parent/module.ts'), './parent');
-			assert.strictEqual(getBasePath('/parent/module'), '/parent');
-			assert.strictEqual(getBasePath('/parent/module.ts'), '/parent');
+			assert.strictEqual(getBasePath('/module'), sep);
+			assert.strictEqual(getBasePath('/module.ts'), sep);
+			assert.strictEqual(getBasePath('./parent/module'), `.${sep}parent`);
+			assert.strictEqual(getBasePath('./parent/module.ts'), `.${sep}parent`);
+			assert.strictEqual(getBasePath('/parent/module'), `${sep}parent`);
+			assert.strictEqual(getBasePath('/parent/module.ts'), `${sep}parent`);
 		});
 	});
 

--- a/tests/unit/webpack.config.ts
+++ b/tests/unit/webpack.config.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from 'fs';
-import { resolve } from 'path';
+import { resolve, sep } from 'path';
 import { createContext, runInContext } from 'vm';
 import { Config } from 'webpack';
 import MockModule from '../support/MockModule';
@@ -126,7 +126,7 @@ describe('webpack.config.ts', () => {
 			const result = imports('./TestModule', 'src/widgets');
 			assert.equal(
 				result,
-				'promise-loader?global,src/widgets/TestModule!./TestModule'
+				`promise-loader?global,src${sep}widgets${sep}TestModule!./TestModule`
 			);
 		});
 


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Changes have been verified with `todo-mvc-kitchensink` on both Windows and Mac. Updates operations that read and manipulate file paths to correctly account for the OS's file separator. Fixes a number of bugs on Windows:

* `umd-compat-loader` now uses the bundle's name.
* `CoreLoadPlugin` maps module IDs correctly.
* `InjectModulesPlugin` is able to load the specified modules.
* Supported locale bundles are properly included in the build.

Resolves #218
