### PR TITLE
Update CI for new release of grunt-dojo2

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -17,7 +17,7 @@ test_script:
   - npm --version
   # run tests
   - node_modules\.bin\grunt.cmd
-  - node_modules\.bin\grunt.cmd intern:local --color
+  - node_modules\.bin\grunt.cmd intern:node --test-reporter --color
   - node_modules\.bin\grunt.cmd uploadCoverage
 
 # Don't actually build.

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ install:
 - travis_retry npm install
 script:
 - grunt
-- grunt intern:local
+- grunt intern:node --test-reporter
 - grunt uploadCoverage
 notifications:
   slack:

--- a/intern.json
+++ b/intern.json
@@ -3,11 +3,11 @@
     "./_build/tests/unit/all.js"
   ],
 
+  "coverage": [
+    "./_build/src/**/*.js"
+  ],
+
   "configs": {
-    "local": {
-      "coverage": [
-        "./_build/src/**/*.js"
-      ]
-    }
+    "local": {}
   }
 }


### PR DESCRIPTION
**Type:** enhancement

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

`grunt-dojo2` has been updated in [a PR](https://github.com/dojo/grunt-dojo2/pull/162) to use Intern 4 exclusively which includes a reporter similar to the one developed for Intern 3. This PR updates the CI scripts to use these features and return the grunt tasks back to feature parity with the tasks before the Intern 4 conversion. The `grunt-dojo2` PR **MUST LAND** and be released before this can land.