### PR TITLE
Update bundle analyzer plugin version

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "typescript": "2.4.2",
     "umd-compat-loader": "2.1.1",
     "webpack": "2.7.0",
-    "webpack-bundle-analyzer-sunburst": "1.2.0",
+    "webpack-bundle-analyzer-sunburst": "1.3.0",
     "webpack-dev-server": "2.6.1"
   }
 }


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
This updates the version of bundle analyzer plugin used by the build process. There aren't really tests in place to validate the output of the build, but I did test it against todo-mvc with and without some additional `bundle` options in `.dojorc`. The convention used is that if there is only one bundle it is still created as `dist/report.html`, and if there are multiple bundles each will get a `dist/report-{bundleName}.html` file.

Resolves #99 
