### PR TITLE
Fix: parse `@dojo/i18n/cldr/load` requires from sequence expressions.

### DIFF
--- a/src/plugins/util/i18n.ts
+++ b/src/plugins/util/i18n.ts
@@ -37,7 +37,7 @@ function getCallExpressionData(expression?: any): { callee?: Identifier, args?: 
 		return {};
 	}
 
-	const { callee, 'arguments': args } = expression;
+	const { callee, arguments: args } = expression;
 	return { callee, args };
 }
 

--- a/src/plugins/util/i18n.ts
+++ b/src/plugins/util/i18n.ts
@@ -1,8 +1,45 @@
 import Map from '@dojo/shim/Map';
-import { CallExpression, Identifier, Program, VariableDeclaration, VariableDeclarator } from 'estree';
+import { CallExpression, Expression, Identifier, Program, SequenceExpression, SpreadElement, VariableDeclaration, VariableDeclarator } from 'estree';
 import * as path from 'path';
 import { getBasePath, isRelative, mergeUnique } from './main';
 import { extractArrayValues, getNextItem, isShadowing } from './parser';
+
+/**
+ * @private
+ * Determines whether the provided expression is a CallExpression.
+ */
+function isCallExpression(expression: any): expression is CallExpression {
+	return expression.type === 'CallExpression';
+}
+
+/**
+ * @private
+ * Determines whether the provided expression is a SequenceExpression.
+ */
+function isSequenceExpression(expression: any): expression is SequenceExpression {
+	return expression.type === 'SequenceExpression';
+}
+
+/**
+ * @private
+ * Resolves the callee and arguments for the provided expression.
+ *
+ * @param expression An AST expression node.
+ * @return An object containing the callee and arguments if the expression is a call expression.
+ */
+function getCallExpressionData(expression?: any): { callee?: Identifier, args?: Array<Expression | SpreadElement> } {
+	if (isSequenceExpression(expression)) {
+		const callExpressions = expression.expressions.filter(expression => isCallExpression(expression)) as CallExpression[];
+		expression = callExpressions[0];
+	}
+
+	if (!expression) {
+		return {};
+	}
+
+	const { callee, 'arguments': args } = expression;
+	return { callee, args };
+}
 
 /**
  * Return an array of URLs that are passed as arguments to `@dojo/i18n/cldr/load.default` in the specified AST program
@@ -160,9 +197,7 @@ export function getLoadImports(ast: Program): string[] {
 		}, [])
 		.filter(((item: VariableDeclarator) => {
 			const expression = item.init as CallExpression;
-			const callee = expression && expression.callee as Identifier;
-			const args = expression && expression.arguments;
-
+			const { callee, args } = getCallExpressionData(expression);
 			return callee && callee.name === 'require' && args && args.length === 1 && /cldr\/load/.test((<any> args[0]).value);
 		}))
 		.map(item => (<Identifier> item.id).name);

--- a/src/plugins/util/i18n.ts
+++ b/src/plugins/util/i18n.ts
@@ -9,7 +9,7 @@ import { extractArrayValues, getNextItem, isShadowing } from './parser';
  * Determines whether the provided expression is a CallExpression.
  */
 function isCallExpression(expression: any): expression is CallExpression {
-	return expression.type === 'CallExpression';
+	return expression && expression.type === 'CallExpression';
 }
 
 /**
@@ -17,7 +17,7 @@ function isCallExpression(expression: any): expression is CallExpression {
  * Determines whether the provided expression is a SequenceExpression.
  */
 function isSequenceExpression(expression: any): expression is SequenceExpression {
-	return expression.type === 'SequenceExpression';
+	return expression && expression.type === 'SequenceExpression';
 }
 
 /**

--- a/tests/support/mocks/ast/README.md
+++ b/tests/support/mocks/ast/README.md
@@ -115,3 +115,10 @@ Promise.resolve().then(() => {
 const load = require('@dojo/i18n/cldr/load');
 load.default([ '../path/to/cldr/data.json' ]);
 ```
+
+`cldr-sequence.json` is the AST object output for the following JavaScript:
+
+```javascript
+const load = (() => {}, require('@dojo/i18n/cldr/load'));
+load.default([ 'cldr-data/supplemental/likelySubtags.json' ]);
+```

--- a/tests/support/mocks/ast/cldr-sequence.json
+++ b/tests/support/mocks/ast/cldr-sequence.json
@@ -1,0 +1,356 @@
+{
+  "type": "Program",
+  "start": 0,
+  "end": 121,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 3,
+      "column": 0
+    }
+  },
+  "range": [
+    0,
+    121
+  ],
+  "body": [
+    {
+      "type": "VariableDeclaration",
+      "start": 0,
+      "end": 57,
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 0
+        },
+        "end": {
+          "line": 1,
+          "column": 57
+        }
+      },
+      "range": [
+        0,
+        57
+      ],
+      "declarations": [
+        {
+          "type": "VariableDeclarator",
+          "start": 6,
+          "end": 56,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 6
+            },
+            "end": {
+              "line": 1,
+              "column": 56
+            }
+          },
+          "range": [
+            6,
+            56
+          ],
+          "id": {
+            "type": "Identifier",
+            "start": 6,
+            "end": 10,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 6
+              },
+              "end": {
+                "line": 1,
+                "column": 10
+              }
+            },
+            "range": [
+              6,
+              10
+            ],
+            "name": "load"
+          },
+          "init": {
+            "type": "SequenceExpression",
+            "start": 14,
+            "end": 55,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 14
+              },
+              "end": {
+                "line": 1,
+                "column": 55
+              }
+            },
+            "range": [
+              14,
+              55
+            ],
+            "expressions": [
+              {
+                "type": "ArrowFunctionExpression",
+                "start": 14,
+                "end": 22,
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 14
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 22
+                  }
+                },
+                "range": [
+                  14,
+                  22
+                ],
+                "id": null,
+                "generator": false,
+                "expression": false,
+                "async": false,
+                "params": [
+
+                ],
+                "body": {
+                  "type": "BlockStatement",
+                  "start": 20,
+                  "end": 22,
+                  "loc": {
+                    "start": {
+                      "line": 1,
+                      "column": 20
+                    },
+                    "end": {
+                      "line": 1,
+                      "column": 22
+                    }
+                  },
+                  "range": [
+                    20,
+                    22
+                  ],
+                  "body": [
+
+                  ]
+                }
+              },
+              {
+                "type": "CallExpression",
+                "start": 24,
+                "end": 55,
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 24
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 55
+                  }
+                },
+                "range": [
+                  24,
+                  55
+                ],
+                "callee": {
+                  "type": "Identifier",
+                  "start": 24,
+                  "end": 31,
+                  "loc": {
+                    "start": {
+                      "line": 1,
+                      "column": 24
+                    },
+                    "end": {
+                      "line": 1,
+                      "column": 31
+                    }
+                  },
+                  "range": [
+                    24,
+                    31
+                  ],
+                  "name": "require"
+                },
+                "arguments": [
+                  {
+                    "type": "Literal",
+                    "start": 32,
+                    "end": 54,
+                    "loc": {
+                      "start": {
+                        "line": 1,
+                        "column": 32
+                      },
+                      "end": {
+                        "line": 1,
+                        "column": 54
+                      }
+                    },
+                    "range": [
+                      32,
+                      54
+                    ],
+                    "value": "@dojo\/i18n\/cldr\/load",
+                    "raw": "'@dojo\/i18n\/cldr\/load'"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ],
+      "kind": "const"
+    },
+    {
+      "type": "ExpressionStatement",
+      "start": 58,
+      "end": 120,
+      "loc": {
+        "start": {
+          "line": 2,
+          "column": 0
+        },
+        "end": {
+          "line": 2,
+          "column": 62
+        }
+      },
+      "range": [
+        58,
+        120
+      ],
+      "expression": {
+        "type": "CallExpression",
+        "start": 58,
+        "end": 119,
+        "loc": {
+          "start": {
+            "line": 2,
+            "column": 0
+          },
+          "end": {
+            "line": 2,
+            "column": 61
+          }
+        },
+        "range": [
+          58,
+          119
+        ],
+        "callee": {
+          "type": "MemberExpression",
+          "start": 58,
+          "end": 70,
+          "loc": {
+            "start": {
+              "line": 2,
+              "column": 0
+            },
+            "end": {
+              "line": 2,
+              "column": 12
+            }
+          },
+          "range": [
+            58,
+            70
+          ],
+          "object": {
+            "type": "Identifier",
+            "start": 58,
+            "end": 62,
+            "loc": {
+              "start": {
+                "line": 2,
+                "column": 0
+              },
+              "end": {
+                "line": 2,
+                "column": 4
+              }
+            },
+            "range": [
+              58,
+              62
+            ],
+            "name": "load"
+          },
+          "property": {
+            "type": "Identifier",
+            "start": 63,
+            "end": 70,
+            "loc": {
+              "start": {
+                "line": 2,
+                "column": 5
+              },
+              "end": {
+                "line": 2,
+                "column": 12
+              }
+            },
+            "range": [
+              63,
+              70
+            ],
+            "name": "default"
+          },
+          "computed": false
+        },
+        "arguments": [
+          {
+            "type": "ArrayExpression",
+            "start": 71,
+            "end": 118,
+            "loc": {
+              "start": {
+                "line": 2,
+                "column": 13
+              },
+              "end": {
+                "line": 2,
+                "column": 60
+              }
+            },
+            "range": [
+              71,
+              118
+            ],
+            "elements": [
+              {
+                "type": "Literal",
+                "start": 73,
+                "end": 116,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 15
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 58
+                  }
+                },
+                "range": [
+                  73,
+                  116
+                ],
+                "value": "cldr-data\/supplemental\/likelySubtags.json",
+                "raw": "'cldr-data\/supplemental\/likelySubtags.json'"
+              }
+            ]
+          }
+        ]
+      }
+    }
+  ],
+  "sourceType": "module"
+}

--- a/tests/unit/plugins/util/i18n.ts
+++ b/tests/unit/plugins/util/i18n.ts
@@ -27,6 +27,25 @@ describe('plugins/util/i18n', () => {
 		it('should parse sequence expressions', () => {
 			assert.sameMembers(getLoadImports(loadAst(Asts.Sequence)), [ 'load' ]);
 		});
+
+		it('should return an empty object when a sequence expression contains no call expressions', () => {
+			const ast = {
+				body: [
+					{
+						type: 'VariableDeclaration',
+						declarations: [
+							{
+								init: {
+									type: 'SequenceExpression',
+									expressions: []
+								}
+							}
+						]
+					}
+				]
+			};
+			assert.lengthOf(getLoadImports(ast as any), 0);
+		});
 	});
 
 	describe('getLoadCallUrls', () => {

--- a/tests/unit/plugins/util/i18n.ts
+++ b/tests/unit/plugins/util/i18n.ts
@@ -8,8 +8,13 @@ const { describe, it } = intern.getInterface('bdd');
 
 declare const require: Require;
 
-function loadAst(complete = true) {
-	const file = complete ? 'complete' : 'relative';
+const enum Asts {
+	Complete = 'complete',
+	Relative = 'relative',
+	Sequence = 'sequence'
+}
+
+function loadAst(file: Asts = Asts.Complete) {
 	return require(`../../../support/mocks/ast/cldr-${file}.json`) as Program;
 }
 
@@ -17,6 +22,10 @@ describe('plugins/util/i18n', () => {
 	describe('getLoadImports', () => {
 		it('should return an array of variable names for `cldr/load` imports', () => {
 			assert.sameMembers(getLoadImports(loadAst()), [ 'load' ]);
+		});
+
+		it('should parse sequence expressions', () => {
+			assert.sameMembers(getLoadImports(loadAst(Asts.Sequence)), [ 'load' ]);
 		});
 	});
 
@@ -51,7 +60,7 @@ describe('plugins/util/i18n', () => {
 		});
 
 		it('should resolve relative urls', () => {
-			assert.sameMembers(getCldrUrls('/parent/context/mid.ts', loadAst(false)), [
+			assert.sameMembers(getCldrUrls('/parent/context/mid.ts', loadAst(Asts.Relative)), [
 				resolve('/parent/path/to/cldr/data.json'.replace(/\//g, sep))
 			]);
 		});


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

`@dojo/i18n/cldr/load.default` can be required from within a sequence expression, which appears to be the case when building an application with the `--withTests` flag. This PR adds a check for such calls, and has been verified against the [`todo-mvc-kitchensink`](https://github.com/dojo/examples) tests.

Resolves #246 
