### PR TITLE
Do not listen only on the loopback interface (#248)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -173,7 +173,7 @@ async function watch(config: webpack.Config, options: WebpackOptions, args: Buil
 	const server = new WebpackDevServer(compiler, options);
 
 	return new Promise<void>((resolve, reject) => {
-		server.listen(serverPort, '127.0.0.1', (err: Error) => {
+		server.listen(serverPort, (err: Error) => {
 			console.log(`Starting server on http://localhost:${serverPort}`);
 			if (err) {
 				reject(err);


### PR DESCRIPTION
This removes the explicit 127.0.0.1 address from the `listen()` method of the
WebpackDevServer launched by the `build --watch` command, as that hinders the
possibility of running it inside a Docker container.

**Type:** feature

The following has been addressed in the PR:

* [X] There is a related issue
* [ ] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Resolves #248
