### PR TITLE
Optimize all js files

### DIFF
--- a/src/webpack.config.ts
+++ b/src/webpack.config.ts
@@ -345,9 +345,6 @@ function webpackConfig(args: Partial<BuildArgs>) {
 				{ test: /@dojo\/.*\.js$/, enforce: 'pre', loader: 'source-map-loader-cli', options: { includeModulePaths: true } },
 				{ test: /src[\\\/].*\.ts?$/, enforce: 'pre', loader: '@dojo/webpack-contrib/css-module-dts-loader?type=ts&instanceName=0_dojo' },
 				{ test: /src[\\\/].*\.m\.css?$/, enforce: 'pre', loader: '@dojo/webpack-contrib/css-module-dts-loader?type=css' },
-				{ test: /\.js(x)?$/, loader: '@dojo/webpack-contrib/static-build-loader', options: {
-					features: args.features
-				}},
 				{ test: /src[\\\/].*\.ts(x)?$/, use: [
 					{
 						loader: '@dojo/webpack-contrib/static-build-loader',
@@ -364,7 +361,15 @@ function webpackConfig(args: Partial<BuildArgs>) {
 						}
 					}
 				]},
-				{ test: /\.js?$/, loader: 'umd-compat-loader' },
+				{ test: /\.js?$/, use: [
+					{
+						loader: '@dojo/webpack-contrib/static-build-loader',
+						options: {
+						features: args.features
+						}
+					},
+					'umd-compat-loader'
+				]},
 				{ test: new RegExp(`globalize(\\${path.sep}|$)`), loader: 'imports-loader?define=>false' },
 				...includeWhen(!args.element, () => {
 					return [

--- a/src/webpack.config.ts
+++ b/src/webpack.config.ts
@@ -365,7 +365,7 @@ function webpackConfig(args: Partial<BuildArgs>) {
 					{
 						loader: '@dojo/webpack-contrib/static-build-loader',
 						options: {
-						features: args.features
+							features: args.features
 						}
 					},
 					'umd-compat-loader'

--- a/src/webpack.config.ts
+++ b/src/webpack.config.ts
@@ -345,6 +345,9 @@ function webpackConfig(args: Partial<BuildArgs>) {
 				{ test: /@dojo\/.*\.js$/, enforce: 'pre', loader: 'source-map-loader-cli', options: { includeModulePaths: true } },
 				{ test: /src[\\\/].*\.ts?$/, enforce: 'pre', loader: '@dojo/webpack-contrib/css-module-dts-loader?type=ts&instanceName=0_dojo' },
 				{ test: /src[\\\/].*\.m\.css?$/, enforce: 'pre', loader: '@dojo/webpack-contrib/css-module-dts-loader?type=css' },
+				{ test: /\.js(x)?$/, loader: '@dojo/webpack-contrib/static-build-loader', options: {
+					features: args.features
+				}},
 				{ test: /src[\\\/].*\.ts(x)?$/, use: [
 					{
 						loader: '@dojo/webpack-contrib/static-build-loader',


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
Previously, the static optimizer plugin has access to all JS files by virtue of the fact that it was accessing the compilation. When I moved it to a loader, I only added it to the `src/**.ts` files. This updates it to properly optimize any JS files in the build.

Resolves #244 
