### PR TITLE
Update custom elements build

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,6 +1,6 @@
 module.exports = function(grunt) {
 	require('grunt-dojo2').initConfig(grunt, {
-		staticDefinitionFiles: [ '**/*.d.ts', '**/*.html', '**/*.md', '**/*.json' ],
+		staticDefinitionFiles: [ '**/*.d.ts', '**/*.html', '**/*.md', '**/*.json', '**/custom-element.js' ],
 		copy: {
 			'staticDefinitionFiles-dev': {
 				expand: true,

--- a/src/main.ts
+++ b/src/main.ts
@@ -83,6 +83,10 @@ function getConfigArgs(args: BuildArgs): Partial<BuildArgs> {
 			if (matches && matches[1]) {
 				options.elementPrefix = matches[1].replace(/[A-Z][a-z]/g, '-\$&').replace(/^-+/g, '').toLowerCase();
 			}
+			else {
+				console.error(`Element prefix could not be determined from element name: "${args.element}". Use --elementPrefix to name element.`);
+				process.exit();
+			}
 		}
 	}
 

--- a/src/templates/custom-element.js
+++ b/src/templates/custom-element.js
@@ -1,0 +1,15 @@
+var registerCustomElement = require('@dojo/widget-core/registerCustomElement').default;
+
+var isFactory;
+try {
+	const descriptor = widgetFactory.default();
+	if (descriptor && typeof descriptor.tagName === 'string') {
+		isFactory = true;
+	}
+}
+catch (e) {
+}
+
+if (isFactory) {
+	registerCustomElement(widgetFactory.default);
+}

--- a/src/templates/custom-element.ts
+++ b/src/templates/custom-element.ts
@@ -1,5 +1,0 @@
-const registerCustomElement: any = require('@dojo/widget-core/registerCustomElement').default;
-
-declare const widgetFactory: any;
-
-registerCustomElement(widgetFactory.default);

--- a/src/webpack.d.ts
+++ b/src/webpack.d.ts
@@ -32,6 +32,16 @@ declare module 'webpack-sources/lib/ConcatSource' {
 	export = ConcatSource;
 }
 
+declare module 'webpack/lib/DefinePlugin' {
+	import webpack = require('webpack');
+
+	class DefinePlugin implements webpack.Plugin {
+		constructor(definitions: { [key: string]: string; });
+		apply(compiler: webpack.Compiler): void;
+	}
+	export = DefinePlugin;
+}
+
 declare module 'webpack-sources/lib/Source' {
 	import * as crypto from 'crypto';
 

--- a/tests/unit/main.ts
+++ b/tests/unit/main.ts
@@ -469,6 +469,19 @@ describe('main', () => {
 				}), JSON.stringify(mockWebpackConfigModule.args));
 			});
 		});
+
+		it('should error if the element prefix cannot be determined', () => {
+			const exitMock = sandbox.stub(process, 'exit');
+
+			return moduleUnderTest.run(getMockConfiguration(), {
+				'element': '/path/to/'
+			}).then(() => {
+				assert.isTrue(exitMock.called);
+				assert.isTrue((<sinon.SinonStub> console.error).calledWith('Element prefix could not be determined from element name: "/path/to/". Use --elementPrefix to name element.'));
+
+				exitMock.restore();
+			});
+		});
 	});
 
 	describe('eject', () => {

--- a/tests/unit/main.ts
+++ b/tests/unit/main.ts
@@ -414,27 +414,42 @@ describe('main', () => {
 			});
 		});
 
-		it('should set the element prefix if it matches the pattern', () => {
+		it('should set the element prefix based on the filename', () => {
 			return moduleUnderTest.run(getMockConfiguration(), {
-				'element': '/path/to/createTestElement.ts'
+				'element': '/path/to/TestWidget.ts'
 			}).then(() => {
 				assert.isTrue(mockWebpackConfigModule.calledWith({
-					element: '/path/to/createTestElement.ts',
-					elementPrefix: 'test'
+					elements: [ { element: '/path/to/TestWidget.ts', prefix: 'test-widget' } ]
 				}), JSON.stringify(mockWebpackConfigModule.args));
 			});
 		});
 
-		it('should error if the element prefix does not match the pattern', () => {
-			const exitMock = sandbox.stub(process, 'exit');
-
+		it('should allow the prefix to be specified', () => {
 			return moduleUnderTest.run(getMockConfiguration(), {
-				'element': '/path/to/myelement.ts'
+				'element': '/path/to/TestWidget.ts',
+				'elementPrefix': 'my-widget'
 			}).then(() => {
-				assert.isTrue(exitMock.called);
-				assert.isTrue((<sinon.SinonStub> console.error).calledWith('"/path/to/myelement.ts" does not follow the pattern "createXYZElement". Use --elementPrefix to name element.'));
+				assert.isTrue(mockWebpackConfigModule.calledWith({
+					elements: [ { element: '/path/to/TestWidget.ts', prefix: 'my-widget' } ]
+				}), JSON.stringify(mockWebpackConfigModule.args));
+			});
+		});
 
-				exitMock.restore();
+		it('should accept an array of elements in .dojorc', () => {
+			return moduleUnderTest.run(getMockConfiguration({
+				'build-webpack': {
+					elements: [
+						{ element: 'path/to/TestWidget.ts', prefix: 'my-widget' },
+						{ element: 'path/to/OtherTestWidget.ts' }
+					]
+				}
+			}), {}).then(() => {
+				assert.isTrue(mockWebpackConfigModule.calledWith({
+					elements: [
+						{ element: 'path/to/TestWidget.ts', prefix: 'my-widget' },
+						{ element: 'path/to/OtherTestWidget.ts', prefix: 'other-test-widget' }
+					]
+				}), JSON.stringify(mockWebpackConfigModule.args));
 			});
 		});
 	});

--- a/tests/unit/main.ts
+++ b/tests/unit/main.ts
@@ -419,7 +419,41 @@ describe('main', () => {
 				'element': '/path/to/TestWidget.ts'
 			}).then(() => {
 				assert.isTrue(mockWebpackConfigModule.calledWith({
-					elements: [ { element: '/path/to/TestWidget.ts', prefix: 'test-widget' } ]
+					element: '/path/to/TestWidget.ts',
+					elementPrefix: 'test-widget'
+				}), JSON.stringify(mockWebpackConfigModule.args));
+			});
+		});
+
+		it('should handle a filename without an extension', () => {
+			return moduleUnderTest.run(getMockConfiguration(), {
+				'element': '/path/to/TestWidget'
+			}).then(() => {
+				assert.isTrue(mockWebpackConfigModule.calledWith({
+					element: '/path/to/TestWidget',
+					elementPrefix: 'test-widget'
+				}), JSON.stringify(mockWebpackConfigModule.args));
+			});
+		});
+
+		it('should support createXElement filename format', () => {
+			return moduleUnderTest.run(getMockConfiguration(), {
+				'element': '/path/to/createTestElement.ts'
+			}).then(() => {
+				assert.isTrue(mockWebpackConfigModule.calledWith({
+					element: '/path/to/createTestElement.ts',
+					elementPrefix: 'test'
+				}), JSON.stringify(mockWebpackConfigModule.args));
+			});
+		});
+
+		it('should support createXElement filename format without an extension', () => {
+			return moduleUnderTest.run(getMockConfiguration(), {
+				'element': '/path/to/createTestElement'
+			}).then(() => {
+				assert.isTrue(mockWebpackConfigModule.calledWith({
+					element: '/path/to/createTestElement',
+					elementPrefix: 'test'
 				}), JSON.stringify(mockWebpackConfigModule.args));
 			});
 		});
@@ -430,25 +464,8 @@ describe('main', () => {
 				'elementPrefix': 'my-widget'
 			}).then(() => {
 				assert.isTrue(mockWebpackConfigModule.calledWith({
-					elements: [ { element: '/path/to/TestWidget.ts', prefix: 'my-widget' } ]
-				}), JSON.stringify(mockWebpackConfigModule.args));
-			});
-		});
-
-		it('should accept an array of elements in .dojorc', () => {
-			return moduleUnderTest.run(getMockConfiguration({
-				'build-webpack': {
-					elements: [
-						{ element: 'path/to/TestWidget.ts', prefix: 'my-widget' },
-						{ element: 'path/to/OtherTestWidget.ts' }
-					]
-				}
-			}), {}).then(() => {
-				assert.isTrue(mockWebpackConfigModule.calledWith({
-					elements: [
-						{ element: 'path/to/TestWidget.ts', prefix: 'my-widget' },
-						{ element: 'path/to/OtherTestWidget.ts', prefix: 'other-test-widget' }
-					]
+					element: '/path/to/TestWidget.ts',
+					elementPrefix: 'my-widget'
 				}), JSON.stringify(mockWebpackConfigModule.args));
 			});
 		});


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Adds support for building a custom element that is defined with the new decorator, and fixes a couple minor issues with the existing custom element build:

* If building a custom element in a dependency, the `--element` flag will not end in `.ts`. Previously this meant that the prefix name could not be automatically determined; this updates it so that it works in either case.
* `templates/custom-element.ts` is compiled with a target of es6 (as are all the ts files), but it gets fed through uglifyJS and runs in the browser. Using `let` breaks this file, and it probably shouldn't be run through that pipeline if doing something perfectly valid in the source file creates invalid output. Now it's a JS file