### PR TITLE
Add Prettier with tslint plugin and precommit hook

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,7 +3,7 @@
 The following has been addressed in the PR:
 
 * [ ] There is a related issue
-* [ ] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
+* [ ] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
 * [ ] Unit or Functional tests are included in the PR
 
 <!--

--- a/README.md
+++ b/README.md
@@ -211,7 +211,17 @@ Types for any dependencies included in `externals` can be installed in `node_mod
 ## How do I contribute?
 
 We appreciate your interest!  Please see the [Dojo 2 Meta Repository](https://github.com/dojo/meta#readme) for the
-Contributing Guidelines and Style Guide.
+Contributing Guidelines.
+
+### Code Style
+
+This repository uses [`prettier`](https://prettier.io/) for code styling rules and formatting. A pre-commit hook is installed automatically and configured to run `prettier` against all staged files as per the configuration in the projects `package.json`.
+
+An additional npm script to run `prettier` (with write set to `true`) against all `src` and `test` project files is available by running:
+
+```bash
+npm run prettier
+```
 
 ### Installation
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dojo/cli-build-webpack",
-  "version": "0.4.0",
+  "version": "0.4.1-pre",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -203,18 +203,6 @@
         "@types/node": "6.0.95"
       }
     },
-    "@types/handlebars": {
-      "version": "4.0.36",
-      "resolved": "https://registry.npmjs.org/@types/handlebars/-/handlebars-4.0.36.tgz",
-      "integrity": "sha512-LjNiTX7TY7wtuC6y3QwC93hKMuqYhgV9A1uXBKNvZtVC8ZvyWAjZkJ5BvT0K7RKqORRYRLMrqCxpw5RgS+MdrQ==",
-      "dev": true
-    },
-    "@types/highlight.js": {
-      "version": "9.12.2",
-      "resolved": "https://registry.npmjs.org/@types/highlight.js/-/highlight.js-9.12.2.tgz",
-      "integrity": "sha512-y5x0XD/WXDaGSyiTaTcKS4FurULJtSiYbGTeQd0m2LYZGBcZZ/7fM6t5H/DzeUF+kv8y6UfmF6yJABQsHcp9VQ==",
-      "dev": true
-    },
     "@types/http-errors": {
       "version": "1.5.34",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-1.5.34.tgz",
@@ -285,12 +273,6 @@
       "integrity": "sha512-k+nc3moSlAaXacyvz4/c6D9lnUeI6AKsLvkXFuNzUEEqMw7sjDnLW2GqlJ4nyFgMX/p+QzvVG6zRoDo4lJIV5g==",
       "dev": true
     },
-    "@types/marked": {
-      "version": "0.0.28",
-      "resolved": "https://registry.npmjs.org/@types/marked/-/marked-0.0.28.tgz",
-      "integrity": "sha1-RLp1Tp+lFDJYPo6zCnxN0km1L6o=",
-      "dev": true
-    },
     "@types/mime": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.0.tgz",
@@ -351,15 +333,6 @@
       "resolved": "https://registry.npmjs.org/@types/shell-quote/-/shell-quote-1.6.0.tgz",
       "integrity": "sha512-BFonQx849sYB2YOJZBUEfbWdaJcqRb6+ASvgUBtcmg2JRTjBaV2Wgn0SD0gWNIZ+rd7KPysPCjLUOUXnBDUlBg==",
       "dev": true
-    },
-    "@types/shelljs": {
-      "version": "0.3.33",
-      "resolved": "https://registry.npmjs.org/@types/shelljs/-/shelljs-0.3.33.tgz",
-      "integrity": "sha1-32E73biCJe0JzlyDX2INyq8VXms=",
-      "dev": true,
-      "requires": {
-        "@types/node": "6.0.95"
-      }
     },
     "@types/sinon": {
       "version": "1.16.36",
@@ -435,24 +408,6 @@
       "integrity": "sha1-ph7VrmkFw66lizplfSUDMJEFJzY=",
       "dev": true
     },
-    "agent-base": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-2.1.1.tgz",
-      "integrity": "sha1-1t4Q1a9hMtW9aSQn1G/FOFOQlMc=",
-      "dev": true,
-      "requires": {
-        "extend": "3.0.1",
-        "semver": "5.0.3"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.0.3",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz",
-          "integrity": "sha1-d0Zt5YnNXTyV8TiqeLxWmjy10no=",
-          "dev": true
-        }
-      }
-    },
     "ajv": {
       "version": "5.5.2",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
@@ -489,22 +444,11 @@
       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
       "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
     },
-    "ansi-align": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
-      "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
-      "requires": {
-        "string-width": "2.1.1"
-      }
-    },
-    "ansi-gray": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-gray/-/ansi-gray-0.1.1.tgz",
-      "integrity": "sha1-KWLPVOyXksSFEKPetSRDaGHvclE=",
-      "dev": true,
-      "requires": {
-        "ansi-wrap": "0.1.0"
-      }
+    "ansi-escapes": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+      "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
+      "dev": true
     },
     "ansi-html": {
       "version": "0.0.7",
@@ -521,16 +465,10 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
       "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
     },
-    "ansi-wrap": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
-      "integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768=",
-      "dev": true
-    },
-    "any-promise": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
-      "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8=",
+    "any-observable": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/any-observable/-/any-observable-0.2.0.tgz",
+      "integrity": "sha1-xnhwBYADV5AJCD9UrAq6+1wz0kI=",
       "dev": true
     },
     "anymatch": {
@@ -541,6 +479,12 @@
         "micromatch": "2.3.11",
         "normalize-path": "2.1.1"
       }
+    },
+    "app-root-path": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/app-root-path/-/app-root-path-2.0.1.tgz",
+      "integrity": "sha1-zWLc+OT9WkF+/GZNLlsQZTxlG0Y=",
+      "dev": true
     },
     "append-transform": {
       "version": "0.4.0",
@@ -571,12 +515,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
       "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
-    },
-    "array-differ": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
-      "integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE=",
-      "dev": true
     },
     "array-filter": {
       "version": "0.0.1",
@@ -623,12 +561,6 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
       "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
-    },
-    "arrify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
-      "dev": true
     },
     "asn1": {
       "version": "0.2.3",
@@ -683,12 +615,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
       "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0="
-    },
-    "asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-      "dev": true
     },
     "auto-require-webpack-plugin": {
       "version": "1.0.1",
@@ -843,12 +769,6 @@
         "tweetnacl": "0.14.5"
       }
     },
-    "beeper": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
-      "integrity": "sha1-5tXqjF2tABMEpwsiY4RH9pyy+Ak=",
-      "dev": true
-    },
     "benchmark": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/benchmark/-/benchmark-2.1.4.tgz",
@@ -959,53 +879,6 @@
       "dev": true,
       "requires": {
         "hoek": "2.16.3"
-      }
-    },
-    "boxen": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.3.0.tgz",
-      "integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
-      "requires": {
-        "ansi-align": "2.0.0",
-        "camelcase": "4.1.0",
-        "chalk": "2.3.0",
-        "cli-boxes": "1.0.0",
-        "string-width": "2.1.1",
-        "term-size": "1.2.0",
-        "widest-line": "2.0.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-          "requires": {
-            "color-convert": "1.9.1"
-          }
-        },
-        "chalk": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
-          "requires": {
-            "ansi-styles": "3.2.0",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "4.5.0"
-          }
-        },
-        "has-flag": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
-        },
-        "supports-color": {
-          "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
-          "requires": {
-            "has-flag": "2.0.0"
-          }
-        }
       }
     },
     "brace-expansion": {
@@ -1170,11 +1043,6 @@
         "upper-case": "1.1.3"
       }
     },
-    "camelcase": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-      "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
-    },
     "camelcase-keys": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
@@ -1206,11 +1074,6 @@
       "version": "1.0.30000784",
       "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000784.tgz",
       "integrity": "sha1-G+lQEtlInHcZB0+BruV9vf/mNhs="
-    },
-    "capture-stack-trace": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
-      "integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0="
     },
     "caseless": {
       "version": "0.11.0",
@@ -1298,6 +1161,12 @@
           }
         }
       }
+    },
+    "ci-info": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.2.tgz",
+      "integrity": "sha512-uTGIPNx/nSpBdsF6xnseRXLLtfr9VLqkz8ZqHXr3Y7b6SftyRxBGjwMtJj1OhNbmlc1wZzLNAlAcvyIiE8a6ZA==",
+      "dev": true
     },
     "cipher-base": {
       "version": "1.0.4",
@@ -1402,10 +1271,52 @@
         "rimraf": "2.6.2"
       }
     },
-    "cli-boxes": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
-      "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM="
+    "cli-cursor": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+      "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+      "dev": true,
+      "requires": {
+        "restore-cursor": "1.0.1"
+      }
+    },
+    "cli-spinners": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-0.1.2.tgz",
+      "integrity": "sha1-u3ZNiOGF+54eaiofGXcjGPYF4xw=",
+      "dev": true
+    },
+    "cli-truncate": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-0.2.1.tgz",
+      "integrity": "sha1-nxXPuwcFAFNpIWxiasfQWrkN1XQ=",
+      "dev": true,
+      "requires": {
+        "slice-ansi": "0.0.4",
+        "string-width": "1.0.2"
+      },
+      "dependencies": {
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "dev": true,
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
+        }
+      }
     },
     "cliui": {
       "version": "3.2.0",
@@ -1441,12 +1352,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.3.tgz",
       "integrity": "sha1-KY1+IjFmD0DAA8LtMUDezz9TCF8="
-    },
-    "clone-stats": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
-      "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE=",
-      "dev": true
     },
     "co": {
       "version": "4.6.0",
@@ -1702,12 +1607,6 @@
         "color-name": "1.1.3"
       }
     },
-    "color-support": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
-      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
-      "dev": true
-    },
     "colormin": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/colormin/-/colormin-1.1.2.tgz",
@@ -1764,49 +1663,6 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
-    "concat-stream": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
-      "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
-      "dev": true,
-      "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.3",
-        "typedarray": "0.0.6"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-          "dev": true,
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
-        }
-      }
-    },
     "config-chain": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.11.tgz",
@@ -1815,19 +1671,6 @@
       "requires": {
         "ini": "1.3.5",
         "proto-list": "1.2.4"
-      }
-    },
-    "configstore": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.1.tgz",
-      "integrity": "sha512-5oNkD/L++l0O6xGXxb1EWS7SivtjfGQlRyxJsYgE0Z495/L81e2h4/d3r969hoPXuFItzNOKMtsXgYG4c7dYvw==",
-      "requires": {
-        "dot-prop": "4.2.0",
-        "graceful-fs": "4.1.11",
-        "make-dir": "1.1.0",
-        "unique-string": "1.0.0",
-        "write-file-atomic": "2.3.0",
-        "xdg-basedir": "3.0.0"
       }
     },
     "connect-history-api-fallback": {
@@ -1948,14 +1791,6 @@
         "elliptic": "6.4.0"
       }
     },
-    "create-error-class": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
-      "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
-      "requires": {
-        "capture-stack-trace": "1.0.0"
-      }
-    },
     "create-hash": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.3.tgz",
@@ -1984,19 +1819,10 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
       "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-      "requires": {
-        "lru-cache": "4.1.1",
-        "shebang-command": "1.2.0",
-        "which": "1.3.0"
-      }
-    },
-    "cross-spawn-async": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/cross-spawn-async/-/cross-spawn-async-2.2.5.tgz",
-      "integrity": "sha1-hF/wwINKPe2dFg2sptOQkGuyiMw=",
       "dev": true,
       "requires": {
         "lru-cache": "4.1.1",
+        "shebang-command": "1.2.0",
         "which": "1.3.0"
       }
     },
@@ -2025,37 +1851,6 @@
         "public-encrypt": "4.0.0",
         "randombytes": "2.0.5",
         "randomfill": "1.0.3"
-      }
-    },
-    "crypto-random-string": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
-      "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4="
-    },
-    "csproj2ts": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/csproj2ts/-/csproj2ts-0.0.7.tgz",
-      "integrity": "sha1-drEJRoMlbponCf1cY+7ya/R6FEI=",
-      "dev": true,
-      "requires": {
-        "es6-promise": "2.3.0",
-        "lodash": "3.10.1",
-        "semver": "5.4.1",
-        "xml2js": "0.4.19"
-      },
-      "dependencies": {
-        "es6-promise": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-2.3.0.tgz",
-          "integrity": "sha1-lu258v2wGZWCKyY92KratnSBgbw=",
-          "dev": true
-        },
-        "lodash": {
-          "version": "3.10.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
-          "dev": true
-        }
       }
     },
     "css-color-function": {
@@ -2264,6 +2059,12 @@
         }
       }
     },
+    "date-fns": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.29.0.tgz",
+      "integrity": "sha512-lbTXWZ6M20cWH8N9S6afb0SBm6tMk+uUg6z3MqHPKE9atmsY3kJkTm8vKe93izJ2B2+q5MV990sM2CHgtAZaOw==",
+      "dev": true
+    },
     "date-now": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
@@ -2381,6 +2182,12 @@
         }
       }
     },
+    "dedent": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
+      "integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
+      "dev": true
+    },
     "deep-eql": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
@@ -2394,17 +2201,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
       "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU="
-    },
-    "deep-extend": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
-      "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8="
-    },
-    "deep-is": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
-      "dev": true
     },
     "default-require-extensions": {
       "version": "1.0.0",
@@ -2481,7 +2277,8 @@
     "diff": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.4.0.tgz",
-      "integrity": "sha512-QpVuMTEoJMF7cKzi6bvWhRulU1fZqZnvyVQgNhPaxxuTYwyjn/j1v9falseQ/uXWwPnO56RBfwtg4h/EQXmucA=="
+      "integrity": "sha512-QpVuMTEoJMF7cKzi6bvWhRulU1fZqZnvyVQgNhPaxxuTYwyjn/j1v9falseQ/uXWwPnO56RBfwtg4h/EQXmucA==",
+      "dev": true
     },
     "diffie-hellman": {
       "version": "5.0.2",
@@ -2573,78 +2370,10 @@
         "domelementtype": "1.3.0"
       }
     },
-    "dot-prop": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
-      "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
-      "requires": {
-        "is-obj": "1.0.1"
-      }
-    },
-    "dts-generator": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/dts-generator/-/dts-generator-2.1.0.tgz",
-      "integrity": "sha1-A5uHpPX4R7O47wDd7j6wlUXezv4=",
-      "dev": true,
-      "requires": {
-        "bluebird": "3.3.3",
-        "glob": "7.0.0",
-        "mkdirp": "0.5.1"
-      },
-      "dependencies": {
-        "bluebird": {
-          "version": "3.3.3",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.3.3.tgz",
-          "integrity": "sha1-z5akXXe5qXpDxGo2XEYZ9iv5dtA=",
-          "dev": true
-        },
-        "glob": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.0.tgz",
-          "integrity": "sha1-OyCjV//89GuzhK7W+K6aZH/basQ=",
-          "dev": true,
-          "requires": {
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
-        }
-      }
-    },
     "duplexer": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
       "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E="
-    },
-    "duplexer2": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
-      "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
-      "dev": true,
-      "requires": {
-        "readable-stream": "1.1.14"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "1.1.14",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-          "dev": true,
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
-          }
-        }
-      }
-    },
-    "duplexer3": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
-      "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
     },
     "ecc-jsbn": {
       "version": "0.1.1",
@@ -2670,6 +2399,12 @@
       "version": "1.3.29",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.29.tgz",
       "integrity": "sha1-elgja5VGjD52YAkTSFItZddzazY="
+    },
+    "elegant-spinner": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/elegant-spinner/-/elegant-spinner-1.0.1.tgz",
+      "integrity": "sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4=",
+      "dev": true
     },
     "elliptic": {
       "version": "6.4.0",
@@ -2736,12 +2471,6 @@
         "is-arrayish": "0.2.1"
       }
     },
-    "es6-promise": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-0.1.2.tgz",
-      "integrity": "sha1-8RLCn+paCZhTn8tqL9IUQ9KPBfc=",
-      "dev": true
-    },
     "es6-templates": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/es6-templates/-/es6-templates-0.2.3.tgz",
@@ -2789,47 +2518,20 @@
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
-    "escodegen": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
-      "integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
+    "eslint-plugin-prettier": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-2.4.0.tgz",
+      "integrity": "sha512-P0EohHM1MwL36GX5l1TOEYyt/5d7hcxrX3CqCjibTN3dH7VCAy2kjsC/WB6dUHnpB4mFkZq1Ndfh2DYQ2QMEGQ==",
       "dev": true,
       "requires": {
-        "esprima": "2.7.3",
-        "estraverse": "1.9.3",
-        "esutils": "2.0.2",
-        "optionator": "0.8.2",
-        "source-map": "0.2.0"
-      },
-      "dependencies": {
-        "esprima": {
-          "version": "2.7.3",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
-          "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
-          "dev": true
-        },
-        "source-map": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
-          "integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "amdefine": "1.0.1"
-          }
-        }
+        "fast-diff": "1.1.2",
+        "jest-docblock": "21.2.0"
       }
     },
     "esprima": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
       "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
-    },
-    "estraverse": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
-      "integrity": "sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q=",
-      "dev": true
     },
     "esutils": {
       "version": "2.0.2",
@@ -2875,9 +2577,10 @@
       }
     },
     "execa": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
-      "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-0.8.0.tgz",
+      "integrity": "sha1-2NdrvBtVIX7RkP1t1J08d07PyNo=",
+      "dev": true,
       "requires": {
         "cross-spawn": "5.1.0",
         "get-stream": "3.0.0",
@@ -2892,6 +2595,12 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
       "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
+      "dev": true
+    },
+    "exit-hook": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
+      "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=",
       "dev": true
     },
     "expand-brackets": {
@@ -2953,15 +2662,6 @@
       "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
       "dev": true
     },
-    "extend-shallow": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-      "dev": true,
-      "requires": {
-        "is-extendable": "0.1.1"
-      }
-    },
     "extglob": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
@@ -2994,40 +2694,21 @@
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
       "dev": true
     },
-    "fancy-log": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.2.tgz",
-      "integrity": "sha1-9BEl49hPLn2JpD0G2VjI94vha+E=",
-      "dev": true,
-      "requires": {
-        "ansi-gray": "0.1.1",
-        "color-support": "1.1.3",
-        "time-stamp": "1.1.0"
-      },
-      "dependencies": {
-        "time-stamp": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.1.0.tgz",
-          "integrity": "sha1-dkpaEa9QVhkhsTPztE5hhofg9cM=",
-          "dev": true
-        }
-      }
-    },
     "fast-deep-equal": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
       "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8="
     },
+    "fast-diff": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.1.2.tgz",
+      "integrity": "sha512-KaJUt+M9t1qaIteSvjc6P3RbMdXsNhK61GRftR6SNxqmhthcd9MGIi4T+o0jD8LUSpSnSKXE20nLtJ3fOHxQig==",
+      "dev": true
+    },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
       "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
-    },
-    "fast-levenshtein": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
-      "dev": true
     },
     "fastparse": {
       "version": "1.1.1",
@@ -3051,6 +2732,16 @@
         "pend": "1.2.0"
       }
     },
+    "figures": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+      "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "1.0.5",
+        "object-assign": "4.1.1"
+      }
+    },
     "file-loader": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-0.10.1.tgz",
@@ -3058,12 +2749,6 @@
       "requires": {
         "loader-utils": "1.1.0"
       }
-    },
-    "file-sync-cmp": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/file-sync-cmp/-/file-sync-cmp-0.1.1.tgz",
-      "integrity": "sha1-peeo/7+kk7Q7kju9TKiaU7Y7YSs=",
-      "dev": true
     },
     "file-type": {
       "version": "5.2.0",
@@ -3107,6 +2792,12 @@
         "unpipe": "1.0.0"
       }
     },
+    "find-parent-dir": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/find-parent-dir/-/find-parent-dir-0.3.0.tgz",
+      "integrity": "sha1-M8RLQpqysvBkYpnF+fcY83b/jVQ=",
+      "dev": true
+    },
     "find-up": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
@@ -3120,6 +2811,7 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.3.0.tgz",
       "integrity": "sha1-N5MKpdgWt3fANEXhlmzGeQpMCxY=",
+      "dev": true,
       "requires": {
         "glob": "5.0.15"
       },
@@ -3128,6 +2820,7 @@
           "version": "5.0.15",
           "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+          "dev": true,
           "requires": {
             "inflight": "1.0.6",
             "inherits": "2.0.3",
@@ -3191,12 +2884,6 @@
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
-    },
-    "fs-exists-sync": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz",
-      "integrity": "sha1-mC1ok6+RjnLQjeyehnP/K1qNat0=",
-      "dev": true
     },
     "fs-extra": {
       "version": "0.26.7",
@@ -4032,29 +3719,6 @@
         "is-property": "1.0.2"
       }
     },
-    "generic-names": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/generic-names/-/generic-names-1.0.3.tgz",
-      "integrity": "sha1-LXhqEhruUIh2eWk56OO/+DbCCRc=",
-      "dev": true,
-      "requires": {
-        "loader-utils": "0.2.17"
-      },
-      "dependencies": {
-        "loader-utils": {
-          "version": "0.2.17",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
-          "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
-          "dev": true,
-          "requires": {
-            "big.js": "3.2.0",
-            "emojis-list": "2.1.0",
-            "json5": "0.5.1",
-            "object-assign": "4.1.1"
-          }
-        }
-      }
-    },
     "get-caller-file": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
@@ -4066,6 +3730,12 @@
       "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
       "dev": true
     },
+    "get-own-enumerable-property-symbols": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-2.0.1.tgz",
+      "integrity": "sha512-TtY/sbOemiMKPRUDDanGCSgBYe7Mf0vbRsWnBZ+9yghpZ1MvcpSpuZFjHdEeY/LZjZy0vdLjS77L6HosisFiug==",
+      "dev": true
+    },
     "get-stdin": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
@@ -4074,7 +3744,8 @@
     "get-stream": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-      "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
+      "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+      "dev": true
     },
     "getobject": {
       "version": "0.1.0",
@@ -4097,17 +3768,6 @@
           "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
           "dev": true
         }
-      }
-    },
-    "git-config-path": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/git-config-path/-/git-config-path-1.0.1.tgz",
-      "integrity": "sha1-bTP37WPbDQ4RgTFQO6s6ykfVRmQ=",
-      "dev": true,
-      "requires": {
-        "extend-shallow": "2.0.1",
-        "fs-exists-sync": "0.1.0",
-        "homedir-polyfill": "1.0.1"
       }
     },
     "glob": {
@@ -4170,14 +3830,6 @@
         }
       }
     },
-    "global-dirs": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
-      "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
-      "requires": {
-        "ini": "1.3.5"
-      }
-    },
     "globalize": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/globalize/-/globalize-1.3.0.tgz",
@@ -4211,33 +3863,6 @@
         "glob": "7.1.2",
         "lodash": "4.17.4",
         "minimatch": "3.0.4"
-      }
-    },
-    "glogg": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.0.tgz",
-      "integrity": "sha1-f+DxmfV6yQbPUS/urY+Q7kooT8U=",
-      "dev": true,
-      "requires": {
-        "sparkles": "1.0.0"
-      }
-    },
-    "got": {
-      "version": "6.7.1",
-      "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
-      "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
-      "requires": {
-        "create-error-class": "3.0.2",
-        "duplexer3": "0.1.4",
-        "get-stream": "3.0.0",
-        "is-redirect": "1.0.0",
-        "is-retry-allowed": "1.1.0",
-        "is-stream": "1.1.0",
-        "lowercase-keys": "1.0.0",
-        "safe-buffer": "5.1.1",
-        "timed-out": "4.0.1",
-        "unzip-response": "2.0.1",
-        "url-parse-lax": "1.0.0"
       }
     },
     "graceful-fs": {
@@ -4331,330 +3956,6 @@
         }
       }
     },
-    "grunt-contrib-clean": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/grunt-contrib-clean/-/grunt-contrib-clean-1.1.0.tgz",
-      "integrity": "sha1-Vkq/LQN4qYOhW54/MO51tzjEBjg=",
-      "dev": true,
-      "requires": {
-        "async": "1.5.2",
-        "rimraf": "2.6.2"
-      },
-      "dependencies": {
-        "async": {
-          "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
-          "dev": true
-        }
-      }
-    },
-    "grunt-contrib-copy": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/grunt-contrib-copy/-/grunt-contrib-copy-1.0.0.tgz",
-      "integrity": "sha1-cGDGWB6QS4qw0A8HbgqPbj58NXM=",
-      "dev": true,
-      "requires": {
-        "chalk": "1.1.3",
-        "file-sync-cmp": "0.1.1"
-      }
-    },
-    "grunt-contrib-watch": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/grunt-contrib-watch/-/grunt-contrib-watch-1.0.0.tgz",
-      "integrity": "sha1-hKGnodar0m7VaEE0lscxM+mQAY8=",
-      "dev": true,
-      "requires": {
-        "async": "1.5.2",
-        "gaze": "1.1.2",
-        "lodash": "3.10.1",
-        "tiny-lr": "0.2.1"
-      },
-      "dependencies": {
-        "async": {
-          "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
-          "dev": true
-        },
-        "lodash": {
-          "version": "3.10.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
-          "dev": true
-        }
-      }
-    },
-    "grunt-dojo2": {
-      "version": "2.0.0-beta2.15",
-      "resolved": "https://registry.npmjs.org/grunt-dojo2/-/grunt-dojo2-2.0.0-beta2.15.tgz",
-      "integrity": "sha512-inDpdjlZrb6F5VTIlMDDCPxN1wtM27axEW9feHrmzh/x1CyelfzsvfkbbmqkP/XHlVrGNmHkO8BuTSDqCDn+BA==",
-      "dev": true,
-      "requires": {
-        "codecov.io": "0.1.6",
-        "cssnano": "3.10.0",
-        "dts-generator": "2.1.0",
-        "execa": "0.4.0",
-        "glob": "7.1.2",
-        "grunt-contrib-clean": "1.1.0",
-        "grunt-contrib-copy": "1.0.0",
-        "grunt-contrib-watch": "1.0.0",
-        "grunt-postcss": "0.8.0",
-        "grunt-text-replace": "0.4.0",
-        "grunt-ts": "5.5.1",
-        "grunt-tslint": "4.0.1",
-        "grunt-typings": "0.1.5",
-        "intern": "4.1.4",
-        "istanbul-lib-coverage": "1.1.1",
-        "istanbul-lib-report": "1.1.2",
-        "istanbul-reports": "1.1.3",
-        "lodash": "4.17.4",
-        "parse-git-config": "0.4.3",
-        "pkg-dir": "1.0.0",
-        "postcss-cssnext": "2.11.0",
-        "postcss-import": "9.1.0",
-        "postcss-modules": "0.6.4",
-        "remap-istanbul": "0.9.5",
-        "resolve-from": "2.0.0",
-        "shelljs": "0.7.8",
-        "tslint": "4.5.1",
-        "typed-css-modules": "0.3.1",
-        "typedoc": "0.5.9",
-        "umd-wrapper": "0.1.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-          "dev": true,
-          "requires": {
-            "color-convert": "1.9.1"
-          }
-        },
-        "chalk": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "3.2.0",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "4.5.0"
-          }
-        },
-        "execa": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-0.4.0.tgz",
-          "integrity": "sha1-TrZGejaglfq7KXD/nV4/t7zm68M=",
-          "dev": true,
-          "requires": {
-            "cross-spawn-async": "2.2.5",
-            "is-stream": "1.1.0",
-            "npm-run-path": "1.0.0",
-            "object-assign": "4.1.1",
-            "path-key": "1.0.0",
-            "strip-eof": "1.0.0"
-          }
-        },
-        "find-up": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-          "dev": true,
-          "requires": {
-            "locate-path": "2.0.0"
-          }
-        },
-        "has-flag": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
-          "dev": true
-        },
-        "load-json-file": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
-          "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "2.2.0",
-            "pify": "2.3.0",
-            "strip-bom": "3.0.0"
-          }
-        },
-        "npm-run-path": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-1.0.0.tgz",
-          "integrity": "sha1-9cMr9ZX+ga6Sfa7FLoL4sACsPI8=",
-          "dev": true,
-          "requires": {
-            "path-key": "1.0.0"
-          }
-        },
-        "os-locale": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
-          "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
-          "dev": true,
-          "requires": {
-            "execa": "0.7.0",
-            "lcid": "1.0.0",
-            "mem": "1.1.0"
-          },
-          "dependencies": {
-            "execa": {
-              "version": "0.7.0",
-              "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
-              "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
-              "dev": true,
-              "requires": {
-                "cross-spawn": "5.1.0",
-                "get-stream": "3.0.0",
-                "is-stream": "1.1.0",
-                "npm-run-path": "2.0.2",
-                "p-finally": "1.0.0",
-                "signal-exit": "3.0.2",
-                "strip-eof": "1.0.0"
-              }
-            },
-            "npm-run-path": {
-              "version": "2.0.2",
-              "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
-              "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
-              "dev": true,
-              "requires": {
-                "path-key": "2.0.1"
-              }
-            },
-            "path-key": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-              "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
-              "dev": true
-            }
-          }
-        },
-        "path-key": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/path-key/-/path-key-1.0.0.tgz",
-          "integrity": "sha1-XVPVeAGWRsDWiADbThRua9wqx68=",
-          "dev": true
-        },
-        "path-type": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
-          "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
-          "dev": true,
-          "requires": {
-            "pify": "2.3.0"
-          }
-        },
-        "postcss-import": {
-          "version": "9.1.0",
-          "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-9.1.0.tgz",
-          "integrity": "sha1-lf6YdqHnmvSfvcNYnwH+WqfMHoA=",
-          "dev": true,
-          "requires": {
-            "object-assign": "4.1.1",
-            "postcss": "5.2.18",
-            "postcss-value-parser": "3.3.0",
-            "promise-each": "2.2.0",
-            "read-cache": "1.0.0",
-            "resolve": "1.5.0"
-          }
-        },
-        "read-pkg": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
-          "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
-          "dev": true,
-          "requires": {
-            "load-json-file": "2.0.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "2.0.0"
-          }
-        },
-        "read-pkg-up": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
-          "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
-          "dev": true,
-          "requires": {
-            "find-up": "2.1.0",
-            "read-pkg": "2.0.0"
-          }
-        },
-        "strip-bom": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
-          "dev": true,
-          "requires": {
-            "has-flag": "2.0.0"
-          }
-        },
-        "typed-css-modules": {
-          "version": "0.3.1",
-          "resolved": "https://registry.npmjs.org/typed-css-modules/-/typed-css-modules-0.3.1.tgz",
-          "integrity": "sha512-RHIKxvl9ytIGM1H13dFTJI44EslhMAZQobY6Do8EIy7JsZI65REQ+N5NHInyOAfvnEWmhIaMrlrDGdLFFIRGow==",
-          "dev": true,
-          "requires": {
-            "camelcase": "4.1.0",
-            "chalk": "2.3.0",
-            "chokidar": "1.7.0",
-            "css-modules-loader-core": "1.1.0",
-            "glob": "7.1.2",
-            "is-there": "4.4.3",
-            "mkdirp": "0.5.1",
-            "yargs": "8.0.2"
-          }
-        },
-        "which-module": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-          "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
-          "dev": true
-        },
-        "yargs": {
-          "version": "8.0.2",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
-          "integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
-          "dev": true,
-          "requires": {
-            "camelcase": "4.1.0",
-            "cliui": "3.2.0",
-            "decamelize": "1.2.0",
-            "get-caller-file": "1.0.2",
-            "os-locale": "2.1.0",
-            "read-pkg-up": "2.0.0",
-            "require-directory": "2.1.1",
-            "require-main-filename": "1.0.1",
-            "set-blocking": "2.0.0",
-            "string-width": "2.1.1",
-            "which-module": "2.0.0",
-            "y18n": "3.2.1",
-            "yargs-parser": "7.0.0"
-          }
-        },
-        "yargs-parser": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
-          "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
-          "dev": true,
-          "requires": {
-            "camelcase": "4.1.0"
-          }
-        }
-      }
-    },
     "grunt-known-options": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/grunt-known-options/-/grunt-known-options-1.1.0.tgz",
@@ -4738,264 +4039,11 @@
         }
       }
     },
-    "grunt-postcss": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/grunt-postcss/-/grunt-postcss-0.8.0.tgz",
-      "integrity": "sha1-jzCor2B5A84MRfAfC+QsYOMc6w4=",
-      "dev": true,
-      "requires": {
-        "chalk": "1.1.3",
-        "diff": "2.2.3",
-        "postcss": "5.2.18"
-      },
-      "dependencies": {
-        "diff": {
-          "version": "2.2.3",
-          "resolved": "https://registry.npmjs.org/diff/-/diff-2.2.3.tgz",
-          "integrity": "sha1-YOr9DSjukG5Oj/ClLBIpUhAzv5k=",
-          "dev": true
-        }
-      }
-    },
-    "grunt-text-replace": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/grunt-text-replace/-/grunt-text-replace-0.4.0.tgz",
-      "integrity": "sha1-252c5Z4v5J2id+nbwZXD4Rz7FsI=",
-      "dev": true
-    },
-    "grunt-ts": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/grunt-ts/-/grunt-ts-5.5.1.tgz",
-      "integrity": "sha1-lXIBxrQhx3cilATwcILY5pnRIZk=",
-      "dev": true,
-      "requires": {
-        "chokidar": "1.0.6",
-        "csproj2ts": "0.0.7",
-        "es6-promise": "0.1.2",
-        "lodash": "2.4.1",
-        "ncp": "0.5.1",
-        "rimraf": "2.2.6",
-        "semver": "5.4.1",
-        "strip-bom": "2.0.0",
-        "typescript": "1.8.9",
-        "underscore": "1.5.1",
-        "underscore.string": "2.3.3"
-      },
-      "dependencies": {
-        "async-each": {
-          "version": "0.1.6",
-          "resolved": "https://registry.npmjs.org/async-each/-/async-each-0.1.6.tgz",
-          "integrity": "sha1-tn6Z7c3fllQeRK9WKQzX1cbnBDk=",
-          "dev": true
-        },
-        "chokidar": {
-          "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.0.6.tgz",
-          "integrity": "sha1-ChwLzh4kmTr8EFpbgeom3aAeI68=",
-          "dev": true,
-          "requires": {
-            "anymatch": "1.3.2",
-            "arrify": "1.0.1",
-            "async-each": "0.1.6",
-            "fsevents": "0.3.8",
-            "glob-parent": "1.3.0",
-            "is-binary-path": "1.0.1",
-            "is-glob": "1.1.3",
-            "path-is-absolute": "1.0.1",
-            "readdirp": "1.4.0"
-          }
-        },
-        "fsevents": {
-          "version": "0.3.8",
-          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-0.3.8.tgz",
-          "integrity": "sha1-mZLxAyySXIKVVNDVmAHcoDE6U1Y=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "nan": "2.8.0"
-          }
-        },
-        "glob-parent": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-1.3.0.tgz",
-          "integrity": "sha1-lx7dgW7V21hwW1gHlkemTQrveWg=",
-          "dev": true,
-          "requires": {
-            "is-glob": "2.0.1"
-          },
-          "dependencies": {
-            "is-glob": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-              "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-              "dev": true,
-              "requires": {
-                "is-extglob": "1.0.0"
-              }
-            }
-          }
-        },
-        "is-extglob": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-          "dev": true
-        },
-        "is-glob": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-1.1.3.tgz",
-          "integrity": "sha1-tMZLgwPTkRRJKkYNNkzPsNPAoEU=",
-          "dev": true
-        },
-        "lodash": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz",
-          "integrity": "sha1-W3cjA03aTSYuWkb7LFjXzCL3FCA=",
-          "dev": true
-        },
-        "lru-cache": {
-          "version": "2.7.3",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
-          "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
-          "dev": true
-        },
-        "minimatch": {
-          "version": "0.2.14",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
-          "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
-          "dev": true,
-          "requires": {
-            "lru-cache": "2.7.3",
-            "sigmund": "1.0.1"
-          }
-        },
-        "readdirp": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-1.4.0.tgz",
-          "integrity": "sha1-xd5vyz3sgFI8HHARPxoZDYr4LIk=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "minimatch": "0.2.14",
-            "readable-stream": "1.0.34"
-          }
-        },
-        "rimraf": {
-          "version": "2.2.6",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.6.tgz",
-          "integrity": "sha1-xZWXVpsU2VatKcrMQr3d9fDqT0w=",
-          "dev": true
-        },
-        "typescript": {
-          "version": "1.8.9",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-1.8.9.tgz",
-          "integrity": "sha1-s7OnQFn9McvT7K2V1iRlk55+1fo=",
-          "dev": true
-        },
-        "underscore": {
-          "version": "1.5.1",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.5.1.tgz",
-          "integrity": "sha1-0r3oF9F2/63olKtxRY5oKhS4bck=",
-          "dev": true
-        },
-        "underscore.string": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
-          "integrity": "sha1-ccCL9rQosRM/N+ePo6Icgvcymw0=",
-          "dev": true
-        }
-      }
-    },
     "grunt-tslint": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/grunt-tslint/-/grunt-tslint-4.0.1.tgz",
-      "integrity": "sha1-dcRuAluereAUYrvrSfb9TBl4O1o=",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/grunt-tslint/-/grunt-tslint-5.0.1.tgz",
+      "integrity": "sha1-dDK9G9VuijolAACI1cYf3MNC8MI=",
       "dev": true
-    },
-    "grunt-typings": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/grunt-typings/-/grunt-typings-0.1.5.tgz",
-      "integrity": "sha1-GluJR6DWBCIxs6oTjACnOjlhW9w=",
-      "dev": true,
-      "requires": {
-        "typings-core": "1.6.1"
-      }
-    },
-    "gulp-util": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.7.tgz",
-      "integrity": "sha1-eJJcS4+LSQBawBoBHFV+YhiUHLs=",
-      "dev": true,
-      "requires": {
-        "array-differ": "1.0.0",
-        "array-uniq": "1.0.3",
-        "beeper": "1.1.1",
-        "chalk": "1.1.3",
-        "dateformat": "1.0.12",
-        "fancy-log": "1.3.2",
-        "gulplog": "1.0.0",
-        "has-gulplog": "0.1.0",
-        "lodash._reescape": "3.0.0",
-        "lodash._reevaluate": "3.0.0",
-        "lodash._reinterpolate": "3.0.0",
-        "lodash.template": "3.6.2",
-        "minimist": "1.2.0",
-        "multipipe": "0.1.2",
-        "object-assign": "3.0.0",
-        "replace-ext": "0.0.1",
-        "through2": "2.0.1",
-        "vinyl": "0.5.3"
-      },
-      "dependencies": {
-        "lodash.template": {
-          "version": "3.6.2",
-          "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
-          "integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
-          "dev": true,
-          "requires": {
-            "lodash._basecopy": "3.0.1",
-            "lodash._basetostring": "3.0.1",
-            "lodash._basevalues": "3.0.0",
-            "lodash._isiterateecall": "3.0.9",
-            "lodash._reinterpolate": "3.0.0",
-            "lodash.escape": "3.2.0",
-            "lodash.keys": "3.1.2",
-            "lodash.restparam": "3.6.1",
-            "lodash.templatesettings": "3.1.1"
-          }
-        },
-        "lodash.templatesettings": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
-          "integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
-          "dev": true,
-          "requires": {
-            "lodash._reinterpolate": "3.0.0",
-            "lodash.escape": "3.2.0"
-          }
-        },
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
-        },
-        "object-assign": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
-          "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I=",
-          "dev": true
-        }
-      }
-    },
-    "gulplog": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
-      "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
-      "dev": true,
-      "requires": {
-        "glogg": "1.0.0"
-      }
     },
     "gzip-size": {
       "version": "3.0.0",
@@ -5139,15 +4187,6 @@
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
       "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
     },
-    "has-gulplog": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
-      "integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
-      "dev": true,
-      "requires": {
-        "sparkles": "1.0.0"
-      }
-    },
     "hash-base": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-2.0.2.tgz",
@@ -5182,12 +4221,6 @@
       "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
       "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0="
     },
-    "highlight.js": {
-      "version": "9.12.0",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.12.0.tgz",
-      "integrity": "sha1-5tnb5Xy+/mB1HwKvM2GVhwyQwB4=",
-      "dev": true
-    },
     "hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
@@ -5203,15 +4236,6 @@
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
       "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
       "dev": true
-    },
-    "homedir-polyfill": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
-      "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
-      "dev": true,
-      "requires": {
-        "parse-passwd": "1.0.0"
-      }
     },
     "hooker": {
       "version": "0.2.3",
@@ -5398,17 +4422,6 @@
         "requires-port": "1.0.0"
       }
     },
-    "http-proxy-agent": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-1.0.0.tgz",
-      "integrity": "sha1-zBzjjkU7+YSg93AtLdWcc9CBKEo=",
-      "dev": true,
-      "requires": {
-        "agent-base": "2.1.1",
-        "debug": "2.6.9",
-        "extend": "3.0.1"
-      }
-    },
     "http-proxy-middleware": {
       "version": "0.17.4",
       "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.17.4.tgz",
@@ -5436,15 +4449,29 @@
       "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
       "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM="
     },
-    "https-proxy-agent": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz",
-      "integrity": "sha1-NffabEjOTdv6JkiRrFk+5f+GceY=",
+    "husky": {
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-0.14.3.tgz",
+      "integrity": "sha512-e21wivqHpstpoiWA/Yi8eFti8E+sQDSS53cpJsPptPs295QTOQR0ZwnHo2TXy1XOpZFD9rPOd3NpmqTK6uMLJA==",
       "dev": true,
       "requires": {
-        "agent-base": "2.1.1",
-        "debug": "2.6.9",
-        "extend": "3.0.1"
+        "is-ci": "1.0.10",
+        "normalize-path": "1.0.0",
+        "strip-indent": "2.0.0"
+      },
+      "dependencies": {
+        "normalize-path": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-1.0.0.tgz",
+          "integrity": "sha1-MtDkcvkf80VwHBWoMRAY07CpA3k=",
+          "dev": true
+        },
+        "strip-indent": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
+          "integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
+          "dev": true
+        }
       }
     },
     "iconv-lite": {
@@ -5468,11 +4495,6 @@
       "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps=",
       "dev": true
     },
-    "import-lazy": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
-      "integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM="
-    },
     "imports-loader": {
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/imports-loader/-/imports-loader-0.7.1.tgz",
@@ -5488,11 +4510,6 @@
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         }
       }
-    },
-    "imurmurhash": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
     },
     "indent-string": {
       "version": "2.1.0",
@@ -5529,7 +4546,8 @@
     "ini": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+      "dev": true
     },
     "intern": {
       "version": "4.1.4",
@@ -5887,16 +4905,6 @@
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.5.2.tgz",
       "integrity": "sha1-1LUFvemUaYfM8PxY2QEP+WB+P6A="
     },
-    "is-absolute": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.2.6.tgz",
-      "integrity": "sha1-IN5p89uULvLYe5wto28XIjWxtes=",
-      "dev": true,
-      "requires": {
-        "is-relative": "0.2.1",
-        "is-windows": "0.2.0"
-      }
-    },
     "is-absolute-url": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-2.1.0.tgz",
@@ -5926,6 +4934,15 @@
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "requires": {
         "builtin-modules": "1.1.1"
+      }
+    },
+    "is-ci": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.0.10.tgz",
+      "integrity": "sha1-9zkzayYyNlBhqdSCcM1WrjNpMY4=",
+      "dev": true,
+      "requires": {
+        "ci-info": "1.1.2"
       }
     },
     "is-directory": {
@@ -5964,26 +4981,12 @@
         "number-is-nan": "1.0.1"
       }
     },
-    "is-fullwidth-code-point": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
-    },
     "is-glob": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
       "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
       "requires": {
         "is-extglob": "2.1.1"
-      }
-    },
-    "is-installed-globally": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
-      "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
-      "requires": {
-        "global-dirs": "0.1.1",
-        "is-path-inside": "1.0.1"
       }
     },
     "is-my-json-valid": {
@@ -6004,11 +5007,6 @@
       "integrity": "sha1-q5124dtM7VHjXeDHLr7PCfc0zeg=",
       "dev": true
     },
-    "is-npm": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
-      "integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ="
-    },
     "is-number": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
@@ -6020,7 +5018,17 @@
     "is-obj": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
-      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
+      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
+      "dev": true
+    },
+    "is-observable": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/is-observable/-/is-observable-0.2.0.tgz",
+      "integrity": "sha1-s2ExHYPG5dcmyr9eJQsCNxBvWuI=",
+      "dev": true,
+      "requires": {
+        "symbol-observable": "0.2.4"
+      }
     },
     "is-path-cwd": {
       "version": "1.0.0",
@@ -6058,35 +5066,29 @@
       "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
       "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
     },
+    "is-promise": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
+      "dev": true
+    },
     "is-property": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
       "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
       "dev": true
     },
-    "is-redirect": {
+    "is-regexp": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
-      "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ="
-    },
-    "is-relative": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.2.1.tgz",
-      "integrity": "sha1-0n9MfVFtF1+2ENuEu+7yPDvJeqU=",
-      "dev": true,
-      "requires": {
-        "is-unc-path": "0.1.2"
-      }
-    },
-    "is-retry-allowed": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
-      "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ="
+      "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
+      "integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk=",
+      "dev": true
     },
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+      "dev": true
     },
     "is-svg": {
       "version": "2.1.0",
@@ -6107,25 +5109,10 @@
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
       "dev": true
     },
-    "is-unc-path": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-0.1.2.tgz",
-      "integrity": "sha1-arBTpyVzwQJQ/0FqOBTDUXivObk=",
-      "dev": true,
-      "requires": {
-        "unc-path-regex": "0.1.2"
-      }
-    },
     "is-utf8": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
       "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
-    },
-    "is-windows": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz",
-      "integrity": "sha1-3hqm1j6indJIc3tp8f+LgALSEIw=",
-      "dev": true
     },
     "isarray": {
       "version": "0.0.1",
@@ -6135,7 +5122,8 @@
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
     },
     "isnumeric": {
       "version": "0.2.0",
@@ -6162,82 +5150,6 @@
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
       "dev": true
-    },
-    "istanbul": {
-      "version": "0.4.5",
-      "resolved": "https://registry.npmjs.org/istanbul/-/istanbul-0.4.5.tgz",
-      "integrity": "sha1-ZcfXPUxNqE1POsMQuRj7C4Azczs=",
-      "dev": true,
-      "requires": {
-        "abbrev": "1.0.9",
-        "async": "1.5.2",
-        "escodegen": "1.8.1",
-        "esprima": "2.7.3",
-        "glob": "5.0.15",
-        "handlebars": "4.0.11",
-        "js-yaml": "3.7.0",
-        "mkdirp": "0.5.1",
-        "nopt": "3.0.6",
-        "once": "1.4.0",
-        "resolve": "1.1.7",
-        "supports-color": "3.2.3",
-        "which": "1.3.0",
-        "wordwrap": "1.0.0"
-      },
-      "dependencies": {
-        "abbrev": {
-          "version": "1.0.9",
-          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
-          "integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU=",
-          "dev": true
-        },
-        "async": {
-          "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
-          "dev": true
-        },
-        "esprima": {
-          "version": "2.7.3",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
-          "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
-          "dev": true
-        },
-        "glob": {
-          "version": "5.0.15",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-          "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-          "dev": true,
-          "requires": {
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
-        },
-        "resolve": {
-          "version": "1.1.7",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-          "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "3.2.3",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-          "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-          "dev": true,
-          "requires": {
-            "has-flag": "1.0.0"
-          }
-        },
-        "wordwrap": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-          "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
-          "dev": true
-        }
-      }
     },
     "istanbul-lib-coverage": {
       "version": "1.1.1",
@@ -6327,6 +5239,67 @@
       "dev": true,
       "requires": {
         "handlebars": "4.0.11"
+      }
+    },
+    "jest-docblock": {
+      "version": "21.2.0",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-21.2.0.tgz",
+      "integrity": "sha512-5IZ7sY9dBAYSV+YjQ0Ovb540Ku7AO9Z5o2Cg789xj167iQuZ2cG+z0f3Uct6WeYLbU6aQiM2pCs7sZ+4dotydw==",
+      "dev": true
+    },
+    "jest-get-type": {
+      "version": "21.2.0",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-21.2.0.tgz",
+      "integrity": "sha512-y2fFw3C+D0yjNSDp7ab1kcd6NUYfy3waPTlD8yWkAtiocJdBRQqNoRqVfMNxgj+IjT0V5cBIHJO0z9vuSSZ43Q==",
+      "dev": true
+    },
+    "jest-validate": {
+      "version": "21.2.1",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-21.2.1.tgz",
+      "integrity": "sha512-k4HLI1rZQjlU+EC682RlQ6oZvLrE5SCh3brseQc24vbZTxzT/k/3urar5QMCVgjadmSO7lECeGdc6YxnM3yEGg==",
+      "dev": true,
+      "requires": {
+        "chalk": "2.3.0",
+        "jest-get-type": "21.2.0",
+        "leven": "2.1.0",
+        "pretty-format": "21.2.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
+          }
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
       }
     },
     "js-base64": {
@@ -6514,14 +5487,6 @@
         "graceful-fs": "4.1.11"
       }
     },
-    "latest-version": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz",
-      "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
-      "requires": {
-        "package-json": "4.0.1"
-      }
-    },
     "lazy-cache": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
@@ -6535,15 +5500,11 @@
         "invert-kv": "1.0.0"
       }
     },
-    "levn": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-      "dev": true,
-      "requires": {
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2"
-      }
+    "leven": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
+      "integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA=",
+      "dev": true
     },
     "lie": {
       "version": "3.1.1",
@@ -6554,17 +5515,218 @@
         "immediate": "3.0.6"
       }
     },
-    "listify": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/listify/-/listify-1.0.0.tgz",
-      "integrity": "sha1-A8p7otFQ1CZ3c/dOV1WNEFPSvuM=",
+    "lint-staged": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-6.0.0.tgz",
+      "integrity": "sha512-ZUftK94S4vedpQG1LlA2tc2AuQXXBwc+1lB+j8SEfG5+p2dqu3Ug8iYQ8jdap+uLkhDw4OaJXqE+CZ/L+vfv+Q==",
+      "dev": true,
+      "requires": {
+        "app-root-path": "2.0.1",
+        "chalk": "2.3.0",
+        "commander": "2.12.2",
+        "cosmiconfig": "3.1.0",
+        "debug": "3.1.0",
+        "dedent": "0.7.0",
+        "execa": "0.8.0",
+        "find-parent-dir": "0.3.0",
+        "is-glob": "4.0.0",
+        "jest-validate": "21.2.1",
+        "listr": "0.13.0",
+        "lodash": "4.17.4",
+        "log-symbols": "2.1.0",
+        "minimatch": "3.0.4",
+        "npm-which": "3.0.1",
+        "p-map": "1.2.0",
+        "path-is-inside": "1.0.2",
+        "pify": "3.0.0",
+        "staged-git-files": "0.0.4",
+        "stringify-object": "3.2.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
+          }
+        },
+        "cosmiconfig": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-3.1.0.tgz",
+          "integrity": "sha512-zedsBhLSbPBms+kE7AH4vHg6JsKDz6epSv2/+5XHs8ILHlgDciSJfSWf8sX9aQ52Jb7KI7VswUTsLpR/G0cr2Q==",
+          "dev": true,
+          "requires": {
+            "is-directory": "0.3.1",
+            "js-yaml": "3.10.0",
+            "parse-json": "3.0.0",
+            "require-from-string": "2.0.1"
+          }
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "dev": true
+        },
+        "is-glob": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
+          "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "2.1.1"
+          }
+        },
+        "js-yaml": {
+          "version": "3.10.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
+          "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
+          "dev": true,
+          "requires": {
+            "argparse": "1.0.9",
+            "esprima": "4.0.0"
+          }
+        },
+        "parse-json": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-3.0.0.tgz",
+          "integrity": "sha1-+m9HsY4jgm6tMvJj50TQ4ehH+xM=",
+          "dev": true,
+          "requires": {
+            "error-ex": "1.3.1"
+          }
+        },
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        },
+        "require-from-string": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.1.tgz",
+          "integrity": "sha1-xUUjPp19pmFunVmt+zn8n1iGdv8=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
+      }
+    },
+    "listr": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/listr/-/listr-0.13.0.tgz",
+      "integrity": "sha1-ILsLowuuZg7oTMBQPfS+PVYjiH0=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "cli-truncate": "0.2.1",
+        "figures": "1.7.0",
+        "indent-string": "2.1.0",
+        "is-observable": "0.2.0",
+        "is-promise": "2.1.0",
+        "is-stream": "1.1.0",
+        "listr-silent-renderer": "1.1.1",
+        "listr-update-renderer": "0.4.0",
+        "listr-verbose-renderer": "0.4.1",
+        "log-symbols": "1.0.2",
+        "log-update": "1.0.2",
+        "ora": "0.2.3",
+        "p-map": "1.2.0",
+        "rxjs": "5.5.6",
+        "stream-to-observable": "0.2.0",
+        "strip-ansi": "3.0.1"
+      },
+      "dependencies": {
+        "log-symbols": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
+          "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
+          "dev": true,
+          "requires": {
+            "chalk": "1.1.3"
+          }
+        }
+      }
+    },
+    "listr-silent-renderer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz",
+      "integrity": "sha1-kktaN1cVN3C/Go4/v3S4u/P5JC4=",
       "dev": true
     },
-    "livereload-js": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/livereload-js/-/livereload-js-2.2.2.tgz",
-      "integrity": "sha1-bIclfmSKtHW8JOoldFftzB+NC8I=",
-      "dev": true
+    "listr-update-renderer": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/listr-update-renderer/-/listr-update-renderer-0.4.0.tgz",
+      "integrity": "sha1-NE2YDaLKLosUW6MFkI8yrj9MyKc=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "cli-truncate": "0.2.1",
+        "elegant-spinner": "1.0.1",
+        "figures": "1.7.0",
+        "indent-string": "3.2.0",
+        "log-symbols": "1.0.2",
+        "log-update": "1.0.2",
+        "strip-ansi": "3.0.1"
+      },
+      "dependencies": {
+        "indent-string": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
+          "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
+          "dev": true
+        },
+        "log-symbols": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
+          "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
+          "dev": true,
+          "requires": {
+            "chalk": "1.1.3"
+          }
+        }
+      }
+    },
+    "listr-verbose-renderer": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/listr-verbose-renderer/-/listr-verbose-renderer-0.4.1.tgz",
+      "integrity": "sha1-ggb0z21S3cWCfl/RSYng6WWTOjU=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "cli-cursor": "1.0.2",
+        "date-fns": "1.29.0",
+        "figures": "1.7.0"
+      }
     },
     "load-json-file": {
       "version": "1.1.0",
@@ -6593,87 +5755,15 @@
         "json5": "0.5.1"
       }
     },
-    "locate-path": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-      "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
-      "dev": true,
-      "requires": {
-        "p-locate": "2.0.0",
-        "path-exists": "3.0.0"
-      },
-      "dependencies": {
-        "path-exists": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-          "dev": true
-        }
-      }
-    },
-    "lockfile": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/lockfile/-/lockfile-1.0.3.tgz",
-      "integrity": "sha1-Jjj8OaAzHpysGgS3F5mTHJxQ33k=",
-      "dev": true
-    },
     "lodash": {
       "version": "4.17.4",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
       "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
     },
-    "lodash._basecopy": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
-      "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
-      "dev": true
-    },
-    "lodash._basetostring": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
-      "integrity": "sha1-0YYdh3+CSlL2aYMtyvPuFVZqB9U=",
-      "dev": true
-    },
-    "lodash._basevalues": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
-      "integrity": "sha1-W3dXYoAr3j0yl1A+JjAIIP32Ybc=",
-      "dev": true
-    },
-    "lodash._getnative": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
-      "dev": true
-    },
-    "lodash._isiterateecall": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
-      "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
-      "dev": true
-    },
-    "lodash._reescape": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
-      "integrity": "sha1-Kx1vXf4HyKNVdT5fJ/rH8c3hYWo=",
-      "dev": true
-    },
-    "lodash._reevaluate": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz",
-      "integrity": "sha1-WLx0xAZklTrgsSTYBpltrKQx4u0=",
-      "dev": true
-    },
     "lodash._reinterpolate": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
       "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
-    },
-    "lodash._root": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
-      "integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI=",
-      "dev": true
     },
     "lodash.assign": {
       "version": "4.2.0",
@@ -6686,48 +5776,10 @@
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
       "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
     },
-    "lodash.escape": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
-      "integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
-      "dev": true,
-      "requires": {
-        "lodash._root": "3.0.1"
-      }
-    },
-    "lodash.isarguments": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
-      "dev": true
-    },
-    "lodash.isarray": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
-      "dev": true
-    },
-    "lodash.keys": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
-      "dev": true,
-      "requires": {
-        "lodash._getnative": "3.9.1",
-        "lodash.isarguments": "3.1.0",
-        "lodash.isarray": "3.0.4"
-      }
-    },
     "lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
       "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4="
-    },
-    "lodash.restparam": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
-      "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
-      "dev": true
     },
     "lodash.template": {
       "version": "4.4.0",
@@ -6750,6 +5802,62 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
       "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
+    },
+    "log-symbols": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.1.0.tgz",
+      "integrity": "sha512-zLeLrzMA1A2vRF1e/0Mo+LNINzi6jzBylHj5WqvQ/WK/5WCZt8si9SyN4p9llr/HRYvVR1AoXHRHl4WTHyQAzQ==",
+      "dev": true,
+      "requires": {
+        "chalk": "2.3.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
+          }
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
+      }
+    },
+    "log-update": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-1.0.2.tgz",
+      "integrity": "sha1-GZKfZMQJPS0ucHWh2tivWcKWuNE=",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "1.4.0",
+        "cli-cursor": "1.0.2"
+      }
     },
     "loglevel": {
       "version": "1.6.0",
@@ -6789,15 +5897,11 @@
       "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
       "integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw="
     },
-    "lowercase-keys": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
-      "integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY="
-    },
     "lru-cache": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
       "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
+      "dev": true,
       "requires": {
         "pseudomap": "1.0.2",
         "yallist": "2.1.2"
@@ -6812,6 +5916,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.1.0.tgz",
       "integrity": "sha512-0Pkui4wLJ7rxvmfUvs87skoEaxmu0hCUApF8nonzpl7q//FWp9zu8W61Scz4sd/kUiqDxvUhtoam2efDyiBzcA==",
+      "dev": true,
       "requires": {
         "pify": "3.0.0"
       },
@@ -6819,35 +5924,15 @@
         "pify": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
         }
-      }
-    },
-    "make-error": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.0.tgz",
-      "integrity": "sha1-Uq06M5zPEM5itAQLcI/nByRLi5Y=",
-      "dev": true
-    },
-    "make-error-cause": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/make-error-cause/-/make-error-cause-1.2.2.tgz",
-      "integrity": "sha1-3wOI/NCzeBbf8KX7gQiTl3fcvJ0=",
-      "dev": true,
-      "requires": {
-        "make-error": "1.3.0"
       }
     },
     "map-obj": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
       "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
-    },
-    "marked": {
-      "version": "0.3.7",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.7.tgz",
-      "integrity": "sha512-zBEP4qO1YQp5aXHt8S5wTiOv9i2X74V/LQL0zhUNvVaklt6Ywa6lChxIvS+ibYlCGgADwKwZFhjC3+XfpsvQvQ==",
-      "dev": true
     },
     "math-expression-evaluator": {
       "version": "1.2.17",
@@ -6878,15 +5963,6 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
-    },
-    "mem": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
-      "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
-      "dev": true,
-      "requires": {
-        "mimic-fn": "1.1.0"
-      }
     },
     "memory-fs": {
       "version": "0.4.1",
@@ -7022,12 +6098,6 @@
         "mime-db": "1.30.0"
       }
     },
-    "mimic-fn": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
-      "integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg=",
-      "dev": true
-    },
     "minimalistic-assert": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz",
@@ -7084,15 +6154,6 @@
       "resolved": "https://registry.npmjs.org/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz",
       "integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE="
     },
-    "multipipe": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
-      "integrity": "sha1-Ko8t33Du1WTf8tV/HhoTfZ8FB4s=",
-      "dev": true,
-      "requires": {
-        "duplexer2": "0.0.2"
-      }
-    },
     "nan": {
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.8.0.tgz",
@@ -7106,12 +6167,6 @@
       "requires": {
         "xml-char-classes": "1.0.0"
       }
-    },
-    "ncp": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/ncp/-/ncp-0.5.1.tgz",
-      "integrity": "sha1-dDmFMW49tFkoG1hxaehFc1oFQ58=",
-      "dev": true
     },
     "negotiator": {
       "version": "0.6.1",
@@ -7248,12 +6303,33 @@
         "sort-keys": "1.1.2"
       }
     },
+    "npm-path": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/npm-path/-/npm-path-2.0.3.tgz",
+      "integrity": "sha1-Fc/04ciaONp39W9gVbJPl137K74=",
+      "dev": true,
+      "requires": {
+        "which": "1.3.0"
+      }
+    },
     "npm-run-path": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+      "dev": true,
       "requires": {
         "path-key": "2.0.1"
+      }
+    },
+    "npm-which": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/npm-which/-/npm-which-3.0.1.tgz",
+      "integrity": "sha1-kiXybsOihcIJyuZ8OxGmtKtxQKo=",
+      "dev": true,
+      "requires": {
+        "commander": "2.12.2",
+        "npm-path": "2.0.3",
+        "which": "1.3.0"
       }
     },
     "npmconf": {
@@ -7328,23 +6404,6 @@
         "is-extendable": "0.1.1"
       }
     },
-    "object.pick": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
-      "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
-      "dev": true,
-      "requires": {
-        "isobject": "3.0.1"
-      },
-      "dependencies": {
-        "isobject": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-          "dev": true
-        }
-      }
-    },
     "obuf": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.1.tgz",
@@ -7376,6 +6435,12 @@
       "resolved": "https://registry.npmjs.org/onecolor/-/onecolor-2.4.2.tgz",
       "integrity": "sha1-pT7D/xccNEYBbdUhDRobVEv32HQ="
     },
+    "onetime": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+      "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
+      "dev": true
+    },
     "opener": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/opener/-/opener-1.4.3.tgz",
@@ -7394,6 +6459,7 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+      "dev": true,
       "requires": {
         "minimist": "0.0.8",
         "wordwrap": "0.0.3"
@@ -7425,26 +6491,16 @@
         }
       }
     },
-    "optionator": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
-      "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+    "ora": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-0.2.3.tgz",
+      "integrity": "sha1-N1J9Igrc1Tw5tzVx11QVbV22V6Q=",
       "dev": true,
       "requires": {
-        "deep-is": "0.1.3",
-        "fast-levenshtein": "2.0.6",
-        "levn": "0.3.0",
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2",
-        "wordwrap": "1.0.0"
-      },
-      "dependencies": {
-        "wordwrap": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-          "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
-          "dev": true
-        }
+        "chalk": "1.1.3",
+        "cli-cursor": "1.0.2",
+        "cli-spinners": "0.1.2",
+        "object-assign": "4.1.1"
       }
     },
     "original": {
@@ -7503,38 +6559,13 @@
     "p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
-    },
-    "p-limit": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz",
-      "integrity": "sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw=",
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
       "dev": true
-    },
-    "p-locate": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-      "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-      "dev": true,
-      "requires": {
-        "p-limit": "1.1.0"
-      }
     },
     "p-map": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/p-map/-/p-map-1.2.0.tgz",
       "integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA=="
-    },
-    "package-json": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
-      "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
-      "requires": {
-        "got": "6.7.1",
-        "registry-auth-token": "3.3.1",
-        "registry-url": "3.1.0",
-        "semver": "5.4.1"
-      }
     },
     "pako": {
       "version": "1.0.6",
@@ -7559,18 +6590,6 @@
         "create-hash": "1.1.3",
         "evp_bytestokey": "1.0.3",
         "pbkdf2": "3.0.14"
-      }
-    },
-    "parse-git-config": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/parse-git-config/-/parse-git-config-0.4.3.tgz",
-      "integrity": "sha1-Z9YiSN1aJOYFP4R1EF8fuelLuwA=",
-      "dev": true,
-      "requires": {
-        "extend-shallow": "2.0.1",
-        "fs-exists-sync": "0.1.0",
-        "git-config-path": "1.0.1",
-        "ini": "1.3.5"
       }
     },
     "parse-glob": {
@@ -7607,12 +6626,6 @@
         "error-ex": "1.3.1"
       }
     },
-    "parse-passwd": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
-      "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
-      "dev": true
-    },
     "parseurl": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
@@ -7644,7 +6657,8 @@
     "path-key": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+      "dev": true
     },
     "path-parse": {
       "version": "1.0.5",
@@ -7745,67 +6759,6 @@
         "onecolor": "2.4.2",
         "postcss": "5.2.18"
       }
-    },
-    "popsicle": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/popsicle/-/popsicle-8.2.0.tgz",
-      "integrity": "sha1-/0QBAFyrQ6lBipFBBhHAAZdxLSE=",
-      "dev": true,
-      "requires": {
-        "any-promise": "1.3.0",
-        "arrify": "1.0.1",
-        "concat-stream": "1.6.0",
-        "form-data": "2.3.1",
-        "make-error-cause": "1.2.2",
-        "throwback": "1.1.1",
-        "tough-cookie": "2.3.3",
-        "xtend": "4.0.1"
-      },
-      "dependencies": {
-        "form-data": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
-          "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
-          "dev": true,
-          "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.5",
-            "mime-types": "2.1.17"
-          }
-        }
-      }
-    },
-    "popsicle-proxy-agent": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/popsicle-proxy-agent/-/popsicle-proxy-agent-3.0.0.tgz",
-      "integrity": "sha1-uRM8VdlFdZq37mG3cRNkYg066tw=",
-      "dev": true,
-      "requires": {
-        "http-proxy-agent": "1.0.0",
-        "https-proxy-agent": "1.0.0"
-      }
-    },
-    "popsicle-retry": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/popsicle-retry/-/popsicle-retry-3.2.1.tgz",
-      "integrity": "sha1-4G6GZTO0KnoSPrMwy+Y6fOvLoQw=",
-      "dev": true,
-      "requires": {
-        "any-promise": "1.3.0",
-        "xtend": "4.0.1"
-      }
-    },
-    "popsicle-rewrite": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/popsicle-rewrite/-/popsicle-rewrite-1.0.0.tgz",
-      "integrity": "sha1-HdTo6pwxgjUfuCD4eTTZkvf7kAc=",
-      "dev": true
-    },
-    "popsicle-status": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/popsicle-status/-/popsicle-status-2.0.1.tgz",
-      "integrity": "sha1-jdcMT+fGlBCa3XhP/oDqysHnso0=",
-      "dev": true
     },
     "portfinder": {
       "version": "1.0.13",
@@ -8436,18 +7389,6 @@
         "postcss-selector-parser": "2.2.3"
       }
     },
-    "postcss-modules": {
-      "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/postcss-modules/-/postcss-modules-0.6.4.tgz",
-      "integrity": "sha1-d6WLt3uhtDkrJwwLWYUv116JqLQ=",
-      "dev": true,
-      "requires": {
-        "css-modules-loader-core": "1.1.0",
-        "generic-names": "1.0.3",
-        "postcss": "5.2.18",
-        "string-hash": "1.1.3"
-      }
-    },
     "postcss-modules-extract-imports": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-1.1.0.tgz",
@@ -8833,12 +7774,6 @@
         "uniqs": "2.0.0"
       }
     },
-    "prelude-ls": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
-      "dev": true
-    },
     "prepend-http": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
@@ -8849,6 +7784,12 @@
       "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
       "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
     },
+    "prettier": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.9.2.tgz",
+      "integrity": "sha512-piXx9N2WT8hWb7PBbX1glAuJVIkEyUV9F5fMXFINpZ0x3otVOFKKeGmeuiclFJlP/UrgTckyV606VjH2rNK4bw==",
+      "dev": true
+    },
     "pretty-error": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/pretty-error/-/pretty-error-2.1.1.tgz",
@@ -8856,6 +7797,33 @@
       "requires": {
         "renderkid": "2.0.1",
         "utila": "0.4.0"
+      }
+    },
+    "pretty-format": {
+      "version": "21.2.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-21.2.1.tgz",
+      "integrity": "sha512-ZdWPGYAnYfcVP8yKA3zFjCn8s4/17TeYH28MXuC8vTp0o21eXjbFGcOAXZEaDaOFJjc3h2qa7HQNHNshhvoh2A==",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "3.0.0",
+        "ansi-styles": "3.2.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        }
       }
     },
     "private": {
@@ -8878,32 +7846,6 @@
       "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
       "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
       "dev": true
-    },
-    "promise-each": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/promise-each/-/promise-each-2.2.0.tgz",
-      "integrity": "sha1-M1MXTv8mlEgQN+BOAfd6oPttG2A=",
-      "dev": true,
-      "requires": {
-        "any-promise": "0.1.0"
-      },
-      "dependencies": {
-        "any-promise": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-0.1.0.tgz",
-          "integrity": "sha1-gwtoCqflbzNFHUsEnzvYBESY7ic=",
-          "dev": true
-        }
-      }
-    },
-    "promise-finally": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/promise-finally/-/promise-finally-2.2.1.tgz",
-      "integrity": "sha1-ImFsS6kCkW6Yi9RsVNfKoIkQzXc=",
-      "dev": true,
-      "requires": {
-        "any-promise": "1.3.0"
-      }
     },
     "promise-loader": {
       "version": "1.0.0",
@@ -8933,7 +7875,8 @@
     "pseudomap": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+      "dev": true
     },
     "public-encrypt": {
       "version": "4.0.0",
@@ -9056,24 +7999,6 @@
         "unpipe": "1.0.0"
       }
     },
-    "rc": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.2.tgz",
-      "integrity": "sha1-2M6ctX6NZNnHut2YdsfDTL48cHc=",
-      "requires": {
-        "deep-extend": "0.4.2",
-        "ini": "1.3.5",
-        "minimist": "1.2.0",
-        "strip-json-comments": "2.0.1"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-        }
-      }
-    },
     "read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -9164,15 +8089,6 @@
         "source-map": "0.6.1"
       }
     },
-    "rechoir": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
-      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
-      "dev": true,
-      "requires": {
-        "resolve": "1.5.0"
-      }
-    },
     "redent": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
@@ -9242,23 +8158,6 @@
         "regjsparser": "0.1.5"
       }
     },
-    "registry-auth-token": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.1.tgz",
-      "integrity": "sha1-+w0yie4Nmtosu1KvXf5mywcNMAY=",
-      "requires": {
-        "rc": "1.2.2",
-        "safe-buffer": "5.1.1"
-      }
-    },
-    "registry-url": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
-      "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
-      "requires": {
-        "rc": "1.2.2"
-      }
-    },
     "regjsgen": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
@@ -9276,20 +8175,6 @@
       "version": "0.2.7",
       "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
       "integrity": "sha1-VNvzd+UUQKypCkzSdGANP/LYiKk="
-    },
-    "remap-istanbul": {
-      "version": "0.9.5",
-      "resolved": "https://registry.npmjs.org/remap-istanbul/-/remap-istanbul-0.9.5.tgz",
-      "integrity": "sha1-oYYXsfMe7Fp9vud1OCmLd1YGqqg=",
-      "dev": true,
-      "requires": {
-        "amdefine": "1.0.1",
-        "gulp-util": "3.0.7",
-        "istanbul": "0.4.5",
-        "minimatch": "3.0.4",
-        "source-map": "0.6.1",
-        "through2": "2.0.1"
-      }
     },
     "remove-trailing-separator": {
       "version": "1.1.0",
@@ -9332,12 +8217,6 @@
       "requires": {
         "is-finite": "1.0.2"
       }
-    },
-    "replace-ext": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
-      "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
-      "dev": true
     },
     "request": {
       "version": "2.74.0",
@@ -9413,11 +8292,15 @@
         "path-parse": "1.0.5"
       }
     },
-    "resolve-from": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
-      "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c=",
-      "dev": true
+    "restore-cursor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
+      "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+      "dev": true,
+      "requires": {
+        "exit-hook": "1.1.1",
+        "onetime": "1.1.0"
+      }
     },
     "resumer": {
       "version": "0.0.0",
@@ -9461,6 +8344,23 @@
       "requires": {
         "hash-base": "2.0.2",
         "inherits": "2.0.3"
+      }
+    },
+    "rxjs": {
+      "version": "5.5.6",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.6.tgz",
+      "integrity": "sha512-v4Q5HDC0FHAQ7zcBX7T2IL6O5ltl1a2GX4ENjPXg6SjDY69Cmx9v4113C99a4wGF16ClPv5Z8mghuYorVkg/kg==",
+      "dev": true,
+      "requires": {
+        "symbol-observable": "1.0.1"
+      },
+      "dependencies": {
+        "symbol-observable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
+          "integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ=",
+          "dev": true
+        }
       }
     },
     "safe-buffer": {
@@ -9524,14 +8424,6 @@
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
       "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
-    },
-    "semver-diff": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
-      "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
-      "requires": {
-        "semver": "5.4.1"
-      }
     },
     "send": {
       "version": "0.16.1",
@@ -9611,6 +8503,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "dev": true,
       "requires": {
         "shebang-regex": "1.0.0"
       }
@@ -9618,7 +8511,8 @@
     "shebang-regex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+      "dev": true
     },
     "shell-quote": {
       "version": "1.6.1",
@@ -9631,23 +8525,6 @@
         "array-reduce": "0.0.0",
         "jsonify": "0.0.0"
       }
-    },
-    "shelljs": {
-      "version": "0.7.8",
-      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.8.tgz",
-      "integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
-      "dev": true,
-      "requires": {
-        "glob": "7.1.2",
-        "interpret": "1.1.0",
-        "rechoir": "0.6.2"
-      }
-    },
-    "sigmund": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
-      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
-      "dev": true
     },
     "signal-exit": {
       "version": "3.0.2",
@@ -9666,10 +8543,10 @@
         "util": "0.10.3"
       }
     },
-    "slide": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
-      "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
+    "slice-ansi": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
+      "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
       "dev": true
     },
     "sntp": {
@@ -9766,12 +8643,6 @@
           }
         }
       }
-    },
-    "sparkles": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz",
-      "integrity": "sha1-Gsu/tZJDbRC76PeFt8xvgoFQEsM=",
-      "dev": true
     },
     "spdx-correct": {
       "version": "1.0.2",
@@ -9885,6 +8756,12 @@
         }
       }
     },
+    "staged-git-files": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/staged-git-files/-/staged-git-files-0.0.4.tgz",
+      "integrity": "sha1-15fhtVHKemOd7AI33G60u5vhfTU=",
+      "dev": true
+    },
     "statuses": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
@@ -9978,51 +8855,35 @@
         }
       }
     },
+    "stream-to-observable": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/stream-to-observable/-/stream-to-observable-0.2.0.tgz",
+      "integrity": "sha1-WdbqOT2HwsDdrBCqDVYbxrpvDhA=",
+      "dev": true,
+      "requires": {
+        "any-observable": "0.2.0"
+      }
+    },
     "strict-uri-encode": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
       "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
     },
-    "string-hash": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/string-hash/-/string-hash-1.1.3.tgz",
-      "integrity": "sha1-6Kr8CsGFW0Zmkp7X3RJ1311sgRs=",
-      "dev": true
-    },
-    "string-template": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/string-template/-/string-template-1.0.0.tgz",
-      "integrity": "sha1-np8iM9wA8hhxjsN5oopWc+zKi5Y=",
-      "dev": true
-    },
-    "string-width": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-      "requires": {
-        "is-fullwidth-code-point": "2.0.0",
-        "strip-ansi": "4.0.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "requires": {
-            "ansi-regex": "3.0.0"
-          }
-        }
-      }
-    },
     "string_decoder": {
       "version": "0.10.31",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
       "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+    },
+    "stringify-object": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-3.2.1.tgz",
+      "integrity": "sha512-jPcQYw/52HUPP8uOE4kkjxl5bB9LfHkKCTptIk3qw7ozP5XMIMlHMLjt00GGSwW6DJAf/njY5EU6Vpwl4LlBKQ==",
+      "dev": true,
+      "requires": {
+        "get-own-enumerable-property-symbols": "2.0.1",
+        "is-obj": "1.0.1",
+        "is-regexp": "1.0.0"
+      }
     },
     "stringstream": {
       "version": "0.0.5",
@@ -10058,7 +8919,8 @@
     "strip-eof": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
+      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+      "dev": true
     },
     "strip-indent": {
       "version": "1.0.1",
@@ -10067,11 +8929,6 @@
       "requires": {
         "get-stdin": "4.0.1"
       }
-    },
-    "strip-json-comments": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
     },
     "style-loader": {
       "version": "0.13.2",
@@ -10099,6 +8956,12 @@
         "sax": "1.2.4",
         "whet.extend": "0.9.9"
       }
+    },
+    "symbol-observable": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-0.2.4.tgz",
+      "integrity": "sha1-lag9smGG1q9+ehjb2XYKL4bQj0A=",
+      "dev": true
     },
     "tapable": {
       "version": "0.2.8",
@@ -10179,29 +9042,6 @@
         }
       }
     },
-    "term-size": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
-      "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
-      "requires": {
-        "execa": "0.7.0"
-      }
-    },
-    "thenify": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.0.tgz",
-      "integrity": "sha1-5p44obq+lpsBCCB5eLn2K4hgSDk=",
-      "dev": true,
-      "requires": {
-        "any-promise": "1.3.0"
-      }
-    },
-    "throat": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/throat/-/throat-3.2.0.tgz",
-      "integrity": "sha512-/EY8VpvlqJ+sFtLPeOgc8Pl7kQVOWv0woD87KTXVHPIAE842FGT+rokxIhe8xIUP1cfgrkt0as0vDLjDiMtr8w==",
-      "dev": true
-    },
     "throttleit": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-0.0.2.tgz",
@@ -10213,47 +9053,6 @@
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
-    "through2": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz",
-      "integrity": "sha1-OE51MU1J8y3hLuu4E2uOtrXVnak=",
-      "dev": true,
-      "requires": {
-        "readable-stream": "2.0.6",
-        "xtend": "4.0.1"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-          "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
-          "dev": true,
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "string_decoder": "0.10.31",
-            "util-deprecate": "1.0.2"
-          }
-        }
-      }
-    },
-    "throwback": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/throwback/-/throwback-1.1.1.tgz",
-      "integrity": "sha1-8AfnwXYEptFtegfEGqDo/txhhKQ=",
-      "dev": true,
-      "requires": {
-        "any-promise": "1.3.0"
-      }
-    },
     "thunky": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/thunky/-/thunky-0.1.0.tgz",
@@ -10264,121 +9063,12 @@
       "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-2.0.0.tgz",
       "integrity": "sha1-lcakRTDhW6jW9KPsuMOj+sRto1c="
     },
-    "timed-out": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
-      "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
-    },
     "timers-browserify": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.4.tgz",
       "integrity": "sha512-uZYhyU3EX8O7HQP+J9fTVYwsq90Vr68xPEFo7yrVImIxYvHgukBEgOB/SgGoorWVTzGM/3Z+wUNnboA4M8jWrg==",
       "requires": {
         "setimmediate": "1.0.5"
-      }
-    },
-    "tiny-lr": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/tiny-lr/-/tiny-lr-0.2.1.tgz",
-      "integrity": "sha1-s/26gC5dVqM8L28QeUsy5Hescp0=",
-      "dev": true,
-      "requires": {
-        "body-parser": "1.14.2",
-        "debug": "2.2.0",
-        "faye-websocket": "0.10.0",
-        "livereload-js": "2.2.2",
-        "parseurl": "1.3.2",
-        "qs": "5.1.0"
-      },
-      "dependencies": {
-        "body-parser": {
-          "version": "1.14.2",
-          "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.14.2.tgz",
-          "integrity": "sha1-EBXLH+LEQ4WCWVgdtTMy+NDPUPk=",
-          "dev": true,
-          "requires": {
-            "bytes": "2.2.0",
-            "content-type": "1.0.4",
-            "debug": "2.2.0",
-            "depd": "1.1.1",
-            "http-errors": "1.3.1",
-            "iconv-lite": "0.4.13",
-            "on-finished": "2.3.0",
-            "qs": "5.2.0",
-            "raw-body": "2.1.7",
-            "type-is": "1.6.15"
-          },
-          "dependencies": {
-            "qs": {
-              "version": "5.2.0",
-              "resolved": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz",
-              "integrity": "sha1-qfMRQq9GjLcrJbMBNrokVoNJFr4=",
-              "dev": true
-            }
-          }
-        },
-        "bytes": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.2.0.tgz",
-          "integrity": "sha1-/TVGSkA/b5EXwt42Cez/nK4ABYg=",
-          "dev": true
-        },
-        "debug": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-          "dev": true,
-          "requires": {
-            "ms": "0.7.1"
-          }
-        },
-        "http-errors": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
-          "integrity": "sha1-GX4izevUGYWF6GlO9nhhl7ke2UI=",
-          "dev": true,
-          "requires": {
-            "inherits": "2.0.3",
-            "statuses": "1.3.1"
-          }
-        },
-        "iconv-lite": {
-          "version": "0.4.13",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz",
-          "integrity": "sha1-H4irpKsLFQjoMSrMOTRfNumS4vI=",
-          "dev": true
-        },
-        "ms": {
-          "version": "0.7.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
-          "dev": true
-        },
-        "qs": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-5.1.0.tgz",
-          "integrity": "sha1-TZMuXH6kEcynajEtOaYGIA/VDNk=",
-          "dev": true
-        },
-        "raw-body": {
-          "version": "2.1.7",
-          "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.1.7.tgz",
-          "integrity": "sha1-rf6s4uT7MJgFgBTQjActzFl1h3Q=",
-          "dev": true,
-          "requires": {
-            "bytes": "2.4.0",
-            "iconv-lite": "0.4.13",
-            "unpipe": "1.0.0"
-          },
-          "dependencies": {
-            "bytes": {
-              "version": "2.4.0",
-              "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.4.0.tgz",
-              "integrity": "sha1-fZcZb51br39pNeJZhVSe3SpsIzk=",
-              "dev": true
-            }
-          }
-        }
       }
     },
     "to-arraybuffer": {
@@ -10395,26 +9085,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/toposort/-/toposort-1.0.6.tgz",
       "integrity": "sha1-wxdI5V0hDv/AD9zcfW5o19e7nOw="
-    },
-    "touch": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/touch/-/touch-1.0.0.tgz",
-      "integrity": "sha1-RJy+LbrlqMgDjjDXH6D/RklHxN4=",
-      "dev": true,
-      "requires": {
-        "nopt": "1.0.10"
-      },
-      "dependencies": {
-        "nopt": {
-          "version": "1.0.10",
-          "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
-          "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
-          "dev": true,
-          "requires": {
-            "abbrev": "1.1.1"
-          }
-        }
-      }
     },
     "tough-cookie": {
       "version": "2.3.3",
@@ -10485,9 +9155,10 @@
       "integrity": "sha1-aUavLR1lGnsYY7Ux1uWvpBqkTqw="
     },
     "tslint": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/tslint/-/tslint-4.5.1.tgz",
-      "integrity": "sha1-BTVocb7yOkNJBnNABvwYgza6gks=",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.2.0.tgz",
+      "integrity": "sha1-FqKt3yDLdIOF9UTpoO2rCGvDQRQ=",
+      "dev": true,
       "requires": {
         "babel-code-frame": "6.26.0",
         "colors": "1.1.2",
@@ -10496,8 +9167,9 @@
         "glob": "7.1.2",
         "optimist": "0.6.1",
         "resolve": "1.5.0",
-        "tsutils": "1.9.1",
-        "update-notifier": "2.3.0"
+        "semver": "5.4.1",
+        "tslib": "1.8.1",
+        "tsutils": "1.9.1"
       }
     },
     "tslint-loader": {
@@ -10512,10 +9184,21 @@
         "semver": "5.4.1"
       }
     },
+    "tslint-plugin-prettier": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tslint-plugin-prettier/-/tslint-plugin-prettier-1.3.0.tgz",
+      "integrity": "sha512-6UqeeV6EABp0RdQkW6eC1vwnAXcKMGJgPeJ5soXiKdSm2vv7c3dp+835CM8pjgx9l4uSa7tICm1Kli+SMsADDg==",
+      "dev": true,
+      "requires": {
+        "eslint-plugin-prettier": "2.4.0",
+        "tslib": "1.8.1"
+      }
+    },
     "tsutils": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-1.9.1.tgz",
-      "integrity": "sha1-ufmrROVa+WgYMdXyjQrur1x1DLA="
+      "integrity": "sha1-ufmrROVa+WgYMdXyjQrur1x1DLA=",
+      "dev": true
     },
     "tty-browserify": {
       "version": "0.0.0",
@@ -10534,15 +9217,6 @@
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "dev": true,
       "optional": true
-    },
-    "type-check": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-      "dev": true,
-      "requires": {
-        "prelude-ls": "1.1.2"
-      }
     },
     "type-detect": {
       "version": "4.0.5",
@@ -10632,262 +9306,10 @@
         }
       }
     },
-    "typedarray": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
-      "dev": true
-    },
-    "typedoc": {
-      "version": "0.5.9",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.5.9.tgz",
-      "integrity": "sha1-40mCQ4tleokM/YXogliz2HWYJBA=",
-      "dev": true,
-      "requires": {
-        "@types/fs-extra": "0.0.33",
-        "@types/handlebars": "4.0.36",
-        "@types/highlight.js": "9.12.2",
-        "@types/lodash": "4.14.91",
-        "@types/marked": "0.0.28",
-        "@types/minimatch": "2.0.29",
-        "@types/shelljs": "0.3.33",
-        "fs-extra": "2.1.2",
-        "handlebars": "4.0.5",
-        "highlight.js": "9.12.0",
-        "lodash": "4.17.4",
-        "marked": "0.3.7",
-        "minimatch": "3.0.4",
-        "progress": "1.1.8",
-        "shelljs": "0.7.8",
-        "typedoc-default-themes": "0.4.4",
-        "typescript": "2.2.1"
-      },
-      "dependencies": {
-        "@types/fs-extra": {
-          "version": "0.0.33",
-          "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-0.0.33.tgz",
-          "integrity": "sha1-qHGcQXsIDAEtNJeyjiKKwJdF/fI=",
-          "dev": true,
-          "requires": {
-            "@types/node": "6.0.95"
-          }
-        },
-        "@types/minimatch": {
-          "version": "2.0.29",
-          "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-2.0.29.tgz",
-          "integrity": "sha1-UALhT3Xi1x5WQoHfBDHIwbSio2o=",
-          "dev": true
-        },
-        "async": {
-          "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
-          "dev": true
-        },
-        "camelcase": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-          "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
-          "dev": true,
-          "optional": true
-        },
-        "cliui": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-          "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "center-align": "0.1.3",
-            "right-align": "0.1.3",
-            "wordwrap": "0.0.2"
-          }
-        },
-        "fs-extra": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-2.1.2.tgz",
-          "integrity": "sha1-BGxwFjzvmq1GsOSn+kZ/si1x3jU=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "jsonfile": "2.4.0"
-          }
-        },
-        "handlebars": {
-          "version": "4.0.5",
-          "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.5.tgz",
-          "integrity": "sha1-ksbta7FkEQxQ1NjQ+93HCAbG+Oc=",
-          "dev": true,
-          "requires": {
-            "async": "1.5.2",
-            "optimist": "0.6.1",
-            "source-map": "0.4.4",
-            "uglify-js": "2.8.29"
-          }
-        },
-        "source-map": {
-          "version": "0.4.4",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-          "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-          "dev": true,
-          "requires": {
-            "amdefine": "1.0.1"
-          }
-        },
-        "typescript": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.2.1.tgz",
-          "integrity": "sha1-SGK2YrmIpMj/aRzHlpYi0k23auk=",
-          "dev": true
-        },
-        "uglify-js": {
-          "version": "2.8.29",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
-          "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "source-map": "0.5.7",
-            "uglify-to-browserify": "1.0.2",
-            "yargs": "3.10.0"
-          },
-          "dependencies": {
-            "source-map": {
-              "version": "0.5.7",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-              "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "window-size": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
-          "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
-          "dev": true,
-          "optional": true
-        },
-        "wordwrap": {
-          "version": "0.0.2",
-          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-          "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
-          "dev": true,
-          "optional": true
-        },
-        "yargs": {
-          "version": "3.10.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-          "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "camelcase": "1.2.1",
-            "cliui": "2.1.0",
-            "decamelize": "1.2.0",
-            "window-size": "0.1.0"
-          }
-        }
-      }
-    },
-    "typedoc-default-themes": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.4.4.tgz",
-      "integrity": "sha1-q+mX3PF0YrYnQ4vGO2XFDTY8JS8=",
-      "dev": true
-    },
     "typescript": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.6.2.tgz",
       "integrity": "sha1-PFtv1/beCRQmkCfwPAlGdY92c6Q="
-    },
-    "typings-core": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/typings-core/-/typings-core-1.6.1.tgz",
-      "integrity": "sha1-zkspMeovGbuPPay+xpmDrE6WSjc=",
-      "dev": true,
-      "requires": {
-        "any-promise": "1.3.0",
-        "array-uniq": "1.0.3",
-        "configstore": "2.1.0",
-        "debug": "2.6.9",
-        "detect-indent": "4.0.0",
-        "graceful-fs": "4.1.11",
-        "has": "1.0.1",
-        "invariant": "2.2.2",
-        "is-absolute": "0.2.6",
-        "listify": "1.0.0",
-        "lockfile": "1.0.3",
-        "make-error-cause": "1.2.2",
-        "mkdirp": "0.5.1",
-        "object.pick": "1.3.0",
-        "parse-json": "2.2.0",
-        "popsicle": "8.2.0",
-        "popsicle-proxy-agent": "3.0.0",
-        "popsicle-retry": "3.2.1",
-        "popsicle-rewrite": "1.0.0",
-        "popsicle-status": "2.0.1",
-        "promise-finally": "2.2.1",
-        "rc": "1.2.2",
-        "rimraf": "2.6.2",
-        "sort-keys": "1.1.2",
-        "string-template": "1.0.0",
-        "strip-bom": "2.0.0",
-        "thenify": "3.3.0",
-        "throat": "3.2.0",
-        "touch": "1.0.0",
-        "typescript": "2.6.2",
-        "xtend": "4.0.1",
-        "zip-object": "0.1.0"
-      },
-      "dependencies": {
-        "configstore": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/configstore/-/configstore-2.1.0.tgz",
-          "integrity": "sha1-c3o6cDbpiGECqmCZ5HuzOrGroaE=",
-          "dev": true,
-          "requires": {
-            "dot-prop": "3.0.0",
-            "graceful-fs": "4.1.11",
-            "mkdirp": "0.5.1",
-            "object-assign": "4.1.1",
-            "os-tmpdir": "1.0.2",
-            "osenv": "0.1.4",
-            "uuid": "2.0.3",
-            "write-file-atomic": "1.3.4",
-            "xdg-basedir": "2.0.0"
-          }
-        },
-        "dot-prop": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-3.0.0.tgz",
-          "integrity": "sha1-G3CK8JSknJoOfbyteQq6U52sEXc=",
-          "dev": true,
-          "requires": {
-            "is-obj": "1.0.1"
-          }
-        },
-        "write-file-atomic": {
-          "version": "1.3.4",
-          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
-          "integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "imurmurhash": "0.1.4",
-            "slide": "1.1.6"
-          }
-        },
-        "xdg-basedir": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-2.0.0.tgz",
-          "integrity": "sha1-7byQPMOF/ARSPZZqM1UEtVBNG9I=",
-          "dev": true,
-          "requires": {
-            "os-homedir": "1.0.2"
-          }
-        }
-      }
     },
     "uglify-js": {
       "version": "3.2.2",
@@ -10961,12 +9383,6 @@
         }
       }
     },
-    "umd-wrapper": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/umd-wrapper/-/umd-wrapper-0.1.0.tgz",
-      "integrity": "sha1-iym4cLCCVDqas7Siooe0uNcVMt4=",
-      "dev": true
-    },
     "unbzip2-stream": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.2.5.tgz",
@@ -11002,12 +9418,6 @@
         }
       }
     },
-    "unc-path-regex": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
-      "integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo=",
-      "dev": true
-    },
     "underscore": {
       "version": "1.8.3",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
@@ -11037,14 +9447,6 @@
       "resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
       "integrity": "sha1-/+3ks2slKQaW5uFl1KWe25mOawI="
     },
-    "unique-string": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
-      "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
-      "requires": {
-        "crypto-random-string": "1.0.0"
-      }
-    },
     "units-css": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/units-css/-/units-css-0.4.0.tgz",
@@ -11058,60 +9460,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
-    },
-    "unzip-response": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz",
-      "integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c="
-    },
-    "update-notifier": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.3.0.tgz",
-      "integrity": "sha1-TognpruRUUCrCTVZ1wFOPruDdFE=",
-      "requires": {
-        "boxen": "1.3.0",
-        "chalk": "2.3.0",
-        "configstore": "3.1.1",
-        "import-lazy": "2.1.0",
-        "is-installed-globally": "0.1.0",
-        "is-npm": "1.0.0",
-        "latest-version": "3.1.0",
-        "semver-diff": "2.1.0",
-        "xdg-basedir": "3.0.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-          "requires": {
-            "color-convert": "1.9.1"
-          }
-        },
-        "chalk": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
-          "requires": {
-            "ansi-styles": "3.2.0",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "4.5.0"
-          }
-        },
-        "has-flag": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
-        },
-        "supports-color": {
-          "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
-          "requires": {
-            "has-flag": "2.0.0"
-          }
-        }
-      }
     },
     "upper-case": {
       "version": "1.1.3",
@@ -11148,14 +9496,6 @@
           "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-1.0.0.tgz",
           "integrity": "sha1-YoYkIRLFtxL6ZU5SZlK/ahP/Bcs="
         }
-      }
-    },
-    "url-parse-lax": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
-      "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
-      "requires": {
-        "prepend-http": "1.0.4"
       }
     },
     "urlgrey": {
@@ -11244,17 +9584,6 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/viewport-dimensions/-/viewport-dimensions-0.2.0.tgz",
       "integrity": "sha1-3nQHR9tTh/0XJfUXXpG6x2r982w="
-    },
-    "vinyl": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
-      "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
-      "dev": true,
-      "requires": {
-        "clone": "1.0.3",
-        "clone-stats": "0.0.1",
-        "replace-ext": "0.0.1"
-      }
     },
     "vm-browserify": {
       "version": "0.0.4",
@@ -11612,6 +9941,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
       "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+      "dev": true,
       "requires": {
         "isexe": "2.0.0"
       }
@@ -11621,14 +9951,6 @@
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
       "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8="
     },
-    "widest-line": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.0.tgz",
-      "integrity": "sha1-AUKk6KJD+IgsAjOqDgKBqnYVInM=",
-      "requires": {
-        "string-width": "2.1.1"
-      }
-    },
     "window-size": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
@@ -11637,7 +9959,8 @@
     "wordwrap": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
+      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+      "dev": true
     },
     "wrap-ansi": {
       "version": "2.1.0",
@@ -11673,16 +9996,6 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
-    "write-file-atomic": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
-      "integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
-      "requires": {
-        "graceful-fs": "4.1.11",
-        "imurmurhash": "0.1.4",
-        "signal-exit": "3.0.2"
-      }
-    },
     "ws": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/ws/-/ws-2.3.1.tgz",
@@ -11701,31 +10014,10 @@
         }
       }
     },
-    "xdg-basedir": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
-      "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ="
-    },
     "xml-char-classes": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/xml-char-classes/-/xml-char-classes-1.0.0.tgz",
       "integrity": "sha1-ZGV4SKIP/F31g6Qq2KJ3tFErvE0="
-    },
-    "xml2js": {
-      "version": "0.4.19",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
-      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
-      "dev": true,
-      "requires": {
-        "sax": "1.2.4",
-        "xmlbuilder": "9.0.4"
-      }
-    },
-    "xmlbuilder": {
-      "version": "9.0.4",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.4.tgz",
-      "integrity": "sha1-UZy0ymhtAFqEINNJbz8MruzKWA8=",
-      "dev": true
     },
     "xtend": {
       "version": "4.0.1",
@@ -11740,7 +10032,8 @@
     "yallist": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+      "dev": true
     },
     "yargs": {
       "version": "5.0.0",
@@ -11832,12 +10125,6 @@
         "buffer-crc32": "0.2.13",
         "fd-slicer": "1.0.1"
       }
-    },
-    "zip-object": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/zip-object/-/zip-object-0.1.0.tgz",
-      "integrity": "sha1-waDaBMiMg3dW4khoCgP/kC7D9To=",
-      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
     "url": "https://github.com/dojo/cli-build.git"
   },
   "scripts": {
+    "precommit": "lint-staged",
+    "prettier": "prettier --write 'src/**/*.ts' 'tests/**/*.ts'",
     "test": "grunt test"
   },
   "devDependencies": {
@@ -39,9 +41,15 @@
     "glob": "^7.0.3",
     "grunt": "~1.0.1",
     "grunt-dojo2": "latest",
+    "grunt-tslint": "5.0.1",
+    "husky": "0.14.3",
     "intern": "~4.1.0",
+    "lint-staged": "6.0.0",
     "mockery": "^1.7.0",
+    "prettier": "1.9.2",
     "sinon": "^1.17.5",
+    "tslint": "5.2.0",
+    "tslint-plugin-prettier": "1.3.0",
     "yargs": "^5.0.0"
   },
   "dependencies": {
@@ -73,7 +81,6 @@
     "source-map-loader-cli": "0.0.1",
     "style-loader": "0.13.2",
     "ts-loader": "3.1.0",
-    "tslint": "4.5.1",
     "tslint-loader": "3.5.3",
     "typed-css-modules": "0.2.0",
     "typescript": "~2.6.1",
@@ -81,5 +88,19 @@
     "webpack": "2.7.0",
     "webpack-bundle-analyzer-sunburst": "1.3.0",
     "webpack-dev-server": "2.6.1"
+  },
+  "lint-staged": {
+    "*.{ts,tsx}": [
+      "prettier --write",
+      "git add"
+    ]
+  },
+  "prettier": {
+    "singleQuote": true,
+    "tabWidth": 4,
+    "useTabs": true,
+    "parser": "typescript",
+    "printWidth": 120,
+    "arrowParens": "always"
   }
 }

--- a/src/loaders/istanbul-loader/loader.ts
+++ b/src/loaders/istanbul-loader/loader.ts
@@ -8,7 +8,7 @@ const { createInstrumenter } = require('istanbul-lib-instrument');
  * @param {string} content the source code
  * @param {object} sourceMap The source map object
  */
-export default function (this: webpack.LoaderContext, content: string, sourceMap?: any) {
+export default function(this: webpack.LoaderContext, content: string, sourceMap?: any) {
 	const callback = this.async();
 
 	const instrumenter = createInstrumenter({
@@ -32,7 +32,12 @@ export default function (this: webpack.LoaderContext, content: string, sourceMap
 		});
 	}
 
-	instrumenter.instrument(content, this.resourcePath, (error: Error, instrumentedSource: string) => {
-		callback(null, instrumentedSource, instrumenter.lastSourceMap());
-	}, sourceMap);
+	instrumenter.instrument(
+		content,
+		this.resourcePath,
+		(error: Error, instrumentedSource: string) => {
+			callback(null, instrumentedSource, instrumenter.lastSourceMap());
+		},
+		sourceMap
+	);
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -46,8 +46,8 @@ interface ConfigFactory {
 interface WebpackOptions {
 	compress: boolean;
 	stats: {
-		colors: boolean
-		chunks: boolean
+		colors: boolean;
+		chunks: boolean;
 	};
 }
 
@@ -60,17 +60,25 @@ function getConfigArgs(args: BuildArgs): Partial<BuildArgs> {
 		const matchesFactoryPattern = elementFileName.match(factoryPattern);
 
 		if (matchesFactoryPattern && matchesFactoryPattern[1]) {
-			options.elementPrefix = matchesFactoryPattern[1].replace(/[A-Z][a-z]/g, '-\$&').replace(/^-+/g, '').toLowerCase();
-		}
-		else {
+			options.elementPrefix = matchesFactoryPattern[1]
+				.replace(/[A-Z][a-z]/g, '-$&')
+				.replace(/^-+/g, '')
+				.toLowerCase();
+		} else {
 			const filePattern = /([^\^/]*)$/;
 			const matches = elementFileName.match(filePattern);
 
 			if (matches && matches[1]) {
-				options.elementPrefix = matches[1].replace(/[A-Z][a-z]/g, '-\$&').replace(/^-+/g, '').toLowerCase();
-			}
-			else {
-				console.error(`Element prefix could not be determined from element name: "${args.element}". Use --elementPrefix to name element.`);
+				options.elementPrefix = matches[1]
+					.replace(/[A-Z][a-z]/g, '-$&')
+					.replace(/^-+/g, '')
+					.toLowerCase();
+			} else {
+				console.error(
+					`Element prefix could not be determined from element name: "${
+						args.element
+					}". Use --elementPrefix to name element.`
+				);
 				process.exit();
 			}
 		}
@@ -95,16 +103,15 @@ async function isPortAvailable(port: number): Promise<boolean> {
 	const server = net.createServer();
 
 	return new Promise<boolean>((resolve, reject) => {
-		server.once('error', function (err: any) {
+		server.once('error', function(err: any) {
 			if (err.code === 'EADDRINUSE') {
 				resolve(false);
-			}
-			else {
+			} else {
 				reject(new Error(`Unexpected error ${err.message}`));
 			}
 		});
 
-		server.once('listening', function () {
+		server.once('listening', function() {
 			server.close();
 			resolve(true);
 		});
@@ -116,14 +123,13 @@ async function isPortAvailable(port: number): Promise<boolean> {
 async function watch(config: webpack.Config, options: WebpackOptions, args: BuildArgs): Promise<void> {
 	config.devtool = 'inline-source-map';
 
-	config.entry = (function (entry) {
+	config.entry = (function(entry) {
 		if (typeof entry === 'object' && !Array.isArray(entry)) {
 			Object.keys(entry).forEach((key) => {
 				const value = entry[key];
 				if (typeof value === 'string') {
-					entry[key] = [ 'webpack-dev-server/client?', value ];
-				}
-				else {
+					entry[key] = ['webpack-dev-server/client?', value];
+				} else {
 					value.unshift('webpack-dev-server/client?');
 				}
 			});
@@ -137,20 +143,18 @@ async function watch(config: webpack.Config, options: WebpackOptions, args: Buil
 	let serverPort: number | undefined;
 
 	if (portRange.indexOf(portRangeDelimeter) >= 0) {
-		let [ low, high ] = portRange.split(portRangeDelimeter).map(portStringToInt);
+		let [low, high] = portRange.split(portRangeDelimeter).map(portStringToInt);
 
 		if (high < low) {
-			[ low, high ] = [ high, low ];
+			[low, high] = [high, low];
 		}
 
 		for (let port = high; port >= low; port--) {
 			ports.push(port);
 		}
-	}
-	else if (portRange.indexOf(portListDelimeter) >= 0) {
+	} else if (portRange.indexOf(portListDelimeter) >= 0) {
 		ports = portRange.split(portListDelimeter).map(portStringToInt);
-	}
-	else {
+	} else {
 		ports.push(portStringToInt(portRange));
 	}
 
@@ -162,7 +166,13 @@ async function watch(config: webpack.Config, options: WebpackOptions, args: Buil
 	}
 
 	if (!serverPort) {
-		return Promise.reject(new Error(`Cannot start a build server because the port is in use, tried ${ports.join(', ')}. Do you already have a build server running?`));
+		return Promise.reject(
+			new Error(
+				`Cannot start a build server because the port is in use, tried ${ports.join(
+					', '
+				)}. Do you already have a build server running?`
+			)
+		);
 	}
 
 	const server = new WebpackDevServer(compiler, options);
@@ -194,7 +204,12 @@ function compile(config: webpack.Config, options: WebpackOptions, args: BuildArg
 
 				console.log(stats.toString(options.stats));
 
-				if (stats.compilation && stats.compilation.errors && stats.compilation.errors.length > 0 && !args.force) {
+				if (
+					stats.compilation &&
+					stats.compilation.errors &&
+					stats.compilation.errors.length > 0 &&
+					!args.force
+				) {
 					reject({
 						exitCode: 1,
 						message: 'The build failed with errors. Use the --force to overcome this obstacle.'
@@ -211,14 +226,13 @@ function buildNpmDependencies(): any {
 	try {
 		const packagePath = pkgDir.sync(__dirname);
 		const packageJsonFilePath = path.join(packagePath, 'package.json');
-		const packageJson = <any> require(packageJsonFilePath);
+		const packageJson = <any>require(packageJsonFilePath);
 
 		return {
 			[packageJson.name]: packageJson.version,
 			...packageJson.dependencies
 		};
-	}
-	catch (e) {
+	} catch (e) {
 		throw new Error('Failed reading dependencies from package.json - ' + e.message);
 	}
 }
@@ -235,7 +249,8 @@ const command: Command<BuildArgs> = {
 
 		options('p', {
 			alias: 'port',
-			describe: 'port to serve on when using --watch. Can be a single port (9999), a range (9999:9990) or a list (9999,9997)',
+			describe:
+				'port to serve on when using --watch. Can be a single port (9999), a range (9999:9990) or a list (9999,9997)',
 			type: 'string'
 		});
 
@@ -281,7 +296,8 @@ const command: Command<BuildArgs> = {
 
 		options('f', {
 			alias: 'features',
-			describe: 'Features sets to optimize the build with\n\nValid values are: android, chrome, edge, firefox, ie11, ios, node, node8, safari',
+			describe:
+				'Features sets to optimize the build with\n\nValid values are: android, chrome, edge, firefox, ie11, ios, node, node8, safari',
 			type: 'array'
 		});
 
@@ -304,8 +320,7 @@ const command: Command<BuildArgs> = {
 
 		if (args.watch) {
 			return watch(config(configArgs), options, args) as Promise<void>;
-		}
-		else {
+		} else {
 			return compile(config(configArgs), options, args) as Promise<void>;
 		}
 	},
@@ -318,12 +333,11 @@ const command: Command<BuildArgs> = {
 			},
 			copy: {
 				path: __dirname,
-				files: [
-					'./webpack.config.js'
-				]
+				files: ['./webpack.config.js']
 			},
 			hints: [
-				'to build run ' + underline('./node_modules/.bin/webpack --config ./config/build-webpack/webpack.config.js')
+				'to build run ' +
+					underline('./node_modules/.bin/webpack --config ./config/build-webpack/webpack.config.js')
 			]
 		};
 

--- a/src/plugins/IgnoreUnmodifiedPlugin.ts
+++ b/src/plugins/IgnoreUnmodifiedPlugin.ts
@@ -22,7 +22,7 @@ export class IgnoreUnmodifiedPlugin {
 				set(_watcher) {
 					watcher = _watcher;
 					const onChange = watcher._onChange;
-					watcher._onChange = function (item: string, mtime: number) {
+					watcher._onChange = function(item: string, mtime: number) {
 						if (!(item in mtimes) || mtimes[item] !== mtime) {
 							mtimes[item] = mtime - FS_ACCURACY;
 							return onChange.apply(watcher, arguments);

--- a/src/postcss.config.ts
+++ b/src/postcss.config.ts
@@ -4,7 +4,7 @@ module.exports = {
 		require('postcss-cssnext')({
 			features: {
 				autoprefixer: {
-					browsers: [ 'last 2 versions', 'ie >= 10' ]
+					browsers: ['last 2 versions', 'ie >= 10']
 				}
 			}
 		})

--- a/src/webpack.config.ts
+++ b/src/webpack.config.ts
@@ -28,14 +28,19 @@ let tslintExists = false;
 try {
 	require(path.join(basePath, 'tslint'));
 	tslintExists = true;
-} catch (ignore) { }
+} catch (ignore) {}
 
 type IncludeCallback = (args: BuildArgs) => any;
 
 function getJsonpFunction(name?: string) {
 	let jsonpFunction = 'dojoWebpackJsonp';
 	if (name) {
-		jsonpFunction += '_' + name.replace(/[^a-z0-9_]/g, ' ').trim().replace(/\s+/g, '_');
+		jsonpFunction +=
+			'_' +
+			name
+				.replace(/[^a-z0-9_]/g, ' ')
+				.trim()
+				.replace(/\s+/g, '_');
 	}
 	return jsonpFunction;
 }
@@ -55,7 +60,7 @@ function getUMDCompatLoader(options: UMDCompatOptions) {
 				const filePath = path.relative(basePath, path.join(context, module));
 				let chunkName = filePath;
 				Object.keys(bundles).some((name) => {
-					const bundlePaths = bundles[name].map(bundlePath => path.normalize(bundlePath));
+					const bundlePaths = bundles[name].map((bundlePath) => path.normalize(bundlePath));
 					if (bundlePaths.indexOf(filePath) > -1) {
 						chunkName = name;
 						return true;
@@ -72,7 +77,7 @@ function webpackConfig(args: Partial<BuildArgs>) {
 	args = args || {};
 
 	const cssLoader = ExtractTextPlugin.extract({ use: 'css-loader?sourceMap' });
-	const localIdentName = (args.watch || args.withTests) ? '[name]__[local]__[hash:base64:5]' : '[hash:base64:8]';
+	const localIdentName = args.watch || args.withTests ? '[name]__[local]__[hash:base64:5]' : '[hash:base64:8]';
 	const externalDependencies = (args.externals && args.externals.dependencies) || [];
 	const includesExternals = Boolean(externalDependencies.length);
 	const cssModuleLoader = ExtractTextPlugin.extract({
@@ -91,14 +96,14 @@ function webpackConfig(args: Partial<BuildArgs>) {
 	});
 
 	function includeWhen(predicate: any, callback: IncludeCallback, elseCallback: IncludeCallback | null = null) {
-		return predicate ? callback(args as any) : (elseCallback ? elseCallback(args as any) : []);
+		return predicate ? callback(args as any) : elseCallback ? elseCallback(args as any) : [];
 	}
 
 	const ignoredModules: string[] = [];
 
 	if (args.bundles && Object.keys(args.bundles)) {
-		Object.keys(args.bundles).forEach(bundleName => {
-			(args.bundles || {})[bundleName].forEach(moduleName => {
+		Object.keys(args.bundles).forEach((bundleName) => {
+			(args.bundles || {})[bundleName].forEach((moduleName) => {
 				ignoredModules.push(moduleName);
 			});
 		});
@@ -116,9 +121,9 @@ function webpackConfig(args: Partial<BuildArgs>) {
 
 	const config: webpack.Config = {
 		externals: [
-			function (context, request, callback) {
+			function(context, request, callback) {
 				const externals = externalDependencies || [];
-				function findExternalType(externals: (string | { name?: string; type?: string; })[]): string | void {
+				function findExternalType(externals: (string | { name?: string; type?: string })[]): string | void {
 					for (let external of externals) {
 						const name = external && (typeof external === 'string' ? external : external.name);
 						if (name && new RegExp(`^${name}[!\/]`).test(request)) {
@@ -135,34 +140,42 @@ function webpackConfig(args: Partial<BuildArgs>) {
 				callback();
 			}
 		],
-		entry: includeWhen(args.element, args => {
-			return {
-				[args.elementPrefix]: `${__dirname}/templates/custom-element.js`,
-				'widget-core': '@dojo/widget-core'
-			};
-		}, args => {
-			return {
-				...includeWhen(args.withTests, () => {
-					return {
-						[`../_build/tests/unit/all`]: [ path.join(basePath, 'tests/unit/all.ts') ],
-						[`../_build/tests/functional/all`]: [ path.join(basePath, 'tests/functional/all.ts') ],
-						[`../_build/src/main`]: [
-							path.join(basePath, 'src/main.css'),
-							path.join(basePath, 'src/main.ts')
-						]
-					};
-				}, () => {
-					return {
-						'src/main': [
-							'@dojo/shim/main',
-							'@dojo/shim/browser',
-							path.join(basePath, 'src/main.css'),
-							path.join(basePath, 'src/main.ts')
-						]
-					};
-				})
-			};
-		}),
+		entry: includeWhen(
+			args.element,
+			(args) => {
+				return {
+					[args.elementPrefix]: `${__dirname}/templates/custom-element.js`,
+					'widget-core': '@dojo/widget-core'
+				};
+			},
+			(args) => {
+				return {
+					...includeWhen(
+						args.withTests,
+						() => {
+							return {
+								[`../_build/tests/unit/all`]: [path.join(basePath, 'tests/unit/all.ts')],
+								[`../_build/tests/functional/all`]: [path.join(basePath, 'tests/functional/all.ts')],
+								[`../_build/src/main`]: [
+									path.join(basePath, 'src/main.css'),
+									path.join(basePath, 'src/main.ts')
+								]
+							};
+						},
+						() => {
+							return {
+								'src/main': [
+									'@dojo/shim/main',
+									'@dojo/shim/browser',
+									path.join(basePath, 'src/main.css'),
+									path.join(basePath, 'src/main.ts')
+								]
+							};
+						}
+					)
+				};
+			}
+		),
 		node: {
 			dgram: 'empty',
 			net: 'empty',
@@ -170,7 +183,7 @@ function webpackConfig(args: Partial<BuildArgs>) {
 			fs: 'empty'
 		},
 		plugins: [
-			new CleanWebpackPlugin([ '_build', 'dist' ], { root: basePath }),
+			new CleanWebpackPlugin(['_build', 'dist'], { root: basePath }),
 			new AutoRequireWebpackPlugin(/src\/main/),
 			new webpack.BannerPlugin(readFileSync(require.resolve(`${packagePath}/banner.md`), 'utf8')),
 			/**
@@ -178,7 +191,7 @@ function webpackConfig(args: Partial<BuildArgs>) {
 			 * in the test bundle, the variable is not scoped at all, so it has, in our case, a function scope in node.
 			 * This little hack makes sure the function is defined by grabbing it from the window scope (jsdom).
 			 */
-			new webpack.BannerPlugin(<any> {
+			new webpack.BannerPlugin(<any>{
 				banner: `var ${jsonpFunctionName} = ${jsonpFunctionName} || window["${jsonpFunctionName}"];`,
 				raw: true,
 				test: /tests\/unit\/all\.*/
@@ -187,65 +200,83 @@ function webpackConfig(args: Partial<BuildArgs>) {
 			new IgnorePlugin(/request\/providers\/node/),
 			new webpack.ContextReplacementPlugin(/dojo-app[\\\/]lib/, { test: () => false }),
 			...includeWhen(args.watch, () => {
-				return [ new IgnoreUnmodifiedPlugin() ];
+				return [new IgnoreUnmodifiedPlugin()];
 			}),
-			...includeWhen(args.element, () => [ new DefinePlugin({
-				__dojoCustomElements__: true
-			}) ]),
-			includeWhen(args.element, args => {
-				return new ExtractTextPlugin({ filename: `${args.elementPrefix}.css` });
-			}, () => {
-				return new ExtractTextPlugin({ filename: 'main.css', allChunks: true });
-			}),
+			...includeWhen(args.element, () => [
+				new DefinePlugin({
+					__dojoCustomElements__: true
+				})
+			]),
+			includeWhen(
+				args.element,
+				(args) => {
+					return new ExtractTextPlugin({ filename: `${args.elementPrefix}.css` });
+				},
+				() => {
+					return new ExtractTextPlugin({ filename: 'main.css', allChunks: true });
+				}
+			),
 			...includeWhen(!args.watch && !args.withTests, () => {
-				return [ new OptimizeCssAssetsPlugin({
-					cssProcessorOptions: {
-						map: { inline: false }
-					}
-				}) ];
+				return [
+					new OptimizeCssAssetsPlugin({
+						cssProcessorOptions: {
+							map: { inline: false }
+						}
+					})
+				];
 			}),
-			includeWhen(args.element, () => {
-				return new CopyWebpackPlugin([
-					{ context: 'src', from: '**/*', ignore: [ '*.ts', '*.css', '*.html' ] }
-				]);
-			}, () => {
-				return new CopyWebpackPlugin([
-					{ context: 'src', from: '**/*', ignore: '*.ts' }
-				]);
-			}),
+			includeWhen(
+				args.element,
+				() => {
+					return new CopyWebpackPlugin([
+						{ context: 'src', from: '**/*', ignore: ['*.ts', '*.css', '*.html'] }
+					]);
+				},
+				() => {
+					return new CopyWebpackPlugin([{ context: 'src', from: '**/*', ignore: '*.ts' }]);
+				}
+			),
 			...includeWhen(args.element, () => {
-				return [ new webpack.optimize.CommonsChunkPlugin({
-					name: 'widget-core',
-					filename: 'widget-core.js'
-				})];
+				return [
+					new webpack.optimize.CommonsChunkPlugin({
+						name: 'widget-core',
+						filename: 'widget-core.js'
+					})
+				];
 			}),
 			...includeWhen(!args.watch && !args.withTests, () => {
-				return [ new webpack.optimize.UglifyJsPlugin({
-					sourceMap: true,
-					compress: { warnings: false },
-					exclude: /tests[/]/
-				}) ];
+				return [
+					new webpack.optimize.UglifyJsPlugin({
+						sourceMap: true,
+						compress: { warnings: false },
+						exclude: /tests[/]/
+					})
+				];
 			}),
-			includeWhen(args.element, args => {
-				return new HtmlWebpackPlugin({
-					inject: false,
-					template: path.join(__dirname, 'templates/custom-element.html'),
-					filename: `${args.elementPrefix}.html`
-				});
-			}, () => {
-				return new HtmlWebpackPlugin({
-					inject: true,
-					chunks: [ 'src/main' ],
-					template: 'src/index.html'
-				});
-			}),
-			...includeWhen(args.locale, args => {
+			includeWhen(
+				args.element,
+				(args) => {
+					return new HtmlWebpackPlugin({
+						inject: false,
+						template: path.join(__dirname, 'templates/custom-element.html'),
+						filename: `${args.elementPrefix}.html`
+					});
+				},
+				() => {
+					return new HtmlWebpackPlugin({
+						inject: true,
+						chunks: ['src/main'],
+						template: 'src/index.html'
+					});
+				}
+			),
+			...includeWhen(args.locale, (args) => {
 				const { cldrPaths, element, locale, supportedLocales = [] } = args;
 				return [
 					new I18nPlugin({
 						cldrPaths,
 						defaultLocale: locale,
-						supportedLocales: Array.isArray(supportedLocales) ? supportedLocales : [ supportedLocales ],
+						supportedLocales: Array.isArray(supportedLocales) ? supportedLocales : [supportedLocales],
 						target: element || path.join(basePath, 'src/main.ts')
 					})
 				];
@@ -261,12 +292,10 @@ function webpackConfig(args: Partial<BuildArgs>) {
 			}),
 			...includeWhen(args.withTests, () => {
 				return [
-					new CopyWebpackPlugin([
-						{context: 'tests', from: '**/*', ignore: '*.ts', to: '../_build/tests' }
-					]),
-					new HtmlWebpackPlugin ({
+					new CopyWebpackPlugin([{ context: 'tests', from: '**/*', ignore: '*.ts', to: '../_build/tests' }]),
+					new HtmlWebpackPlugin({
 						inject: true,
-						chunks: [ 'src', '../_build/src/main' ],
+						chunks: ['src', '../_build/src/main'],
 						template: 'src/index.html',
 						filename: '../_build/src/index.html'
 					}),
@@ -275,13 +304,14 @@ function webpackConfig(args: Partial<BuildArgs>) {
 						filename: '../_build/src/src.js',
 						chunks: ['../_build/src/main', '../_build/tests/unit/all'],
 						minChunks: (module: any) => {
-							if (module.resource && !(/^.*\.(ts)$/).test(module.resource)) {
+							if (module.resource && !/^.*\.(ts)$/.test(module.resource)) {
 								return false;
 							}
 
 							return module.context && module.context.indexOf('src/') !== -1;
 						}
-					})];
+					})
+				];
 			}),
 			...includeWhen(includesExternals, () => [
 				new ExternalLoaderPlugin({
@@ -291,100 +321,126 @@ function webpackConfig(args: Partial<BuildArgs>) {
 				})
 			])
 		],
-		output: includeWhen(args.element, args => {
-			return Object.assign(outputConfig, {
-				libraryTarget: 'jsonp',
-				path: path.resolve(`./dist/${args.elementPrefix}`)
-			});
-		}, () => {
-			return Object.assign(outputConfig, {
-				library: '[name]',
-				umdNamedDefine: true
-			});
-		}),
+		output: includeWhen(
+			args.element,
+			(args) => {
+				return Object.assign(outputConfig, {
+					libraryTarget: 'jsonp',
+					path: path.resolve(`./dist/${args.elementPrefix}`)
+				});
+			},
+			() => {
+				return Object.assign(outputConfig, {
+					library: '[name]',
+					umdNamedDefine: true
+				});
+			}
+		),
 		devtool: 'source-map',
 		resolve: {
-			modules: [
-				basePath,
-				path.join(basePath, 'node_modules')
-			],
+			modules: [basePath, path.join(basePath, 'node_modules')],
 			extensions: ['.ts', '.tsx', '.js']
 		},
-			resolveLoader: {
-				modules: [
-					path.join(isCLI ? __dirname : 'node_modules/@dojo/cli-build-webpack', 'loaders'),
-					path.join(__dirname, 'node_modules'),
-					'node_modules' ]
-			},
-			module: {
-				rules: [
-					...includeWhen(tslintExists, () => {
-						return [
-							{
-								test: /\.ts$/,
-								enforce: 'pre',
-								loader: 'tslint-loader',
-								options: {
-									tsConfigFile: path.join(basePath, 'tslint.json'),
+		resolveLoader: {
+			modules: [
+				path.join(isCLI ? __dirname : 'node_modules/@dojo/cli-build-webpack', 'loaders'),
+				path.join(__dirname, 'node_modules'),
+				'node_modules'
+			]
+		},
+		module: {
+			rules: [
+				...includeWhen(tslintExists, () => {
+					return [
+						{
+							test: /\.ts$/,
+							enforce: 'pre',
+							loader: 'tslint-loader',
+							options: {
+								tsConfigFile: path.join(basePath, 'tslint.json'),
 								...includeWhen(!args.watch && !args.withTests, () => {
 									return {
 										emitErrors: true,
 										failOnHint: true
 									};
-								})}
+								})
+							}
 						}
 					];
 				}),
-				{ test: /@dojo\/.*\.js$/, enforce: 'pre', loader: 'source-map-loader-cli', options: { includeModulePaths: true } },
-				{ test: /src[\\\/].*\.ts?$/, enforce: 'pre', loader: '@dojo/webpack-contrib/css-module-dts-loader?type=ts&instanceName=0_dojo' },
-				{ test: /src[\\\/].*\.m\.css?$/, enforce: 'pre', loader: '@dojo/webpack-contrib/css-module-dts-loader?type=css' },
-				{ test: /src[\\\/].*\.ts(x)?$/, use: [
-					{
-						loader: '@dojo/webpack-contrib/static-build-loader',
-						options: {
-							features: args.features
+				{
+					test: /@dojo\/.*\.js$/,
+					enforce: 'pre',
+					loader: 'source-map-loader-cli',
+					options: { includeModulePaths: true }
+				},
+				{
+					test: /src[\\\/].*\.ts?$/,
+					enforce: 'pre',
+					loader: '@dojo/webpack-contrib/css-module-dts-loader?type=ts&instanceName=0_dojo'
+				},
+				{
+					test: /src[\\\/].*\.m\.css?$/,
+					enforce: 'pre',
+					loader: '@dojo/webpack-contrib/css-module-dts-loader?type=css'
+				},
+				{
+					test: /src[\\\/].*\.ts(x)?$/,
+					use: [
+						{
+							loader: '@dojo/webpack-contrib/static-build-loader',
+							options: {
+								features: args.features
+							}
+						},
+						getUMDCompatLoader({ bundles: args.bundles }),
+						{
+							loader: 'ts-loader',
+							options: {
+								instance: 'dojo',
+								onlyCompileBundledFiles: true
+							}
 						}
-					},
-					getUMDCompatLoader({ bundles: args.bundles }),
-					{
-						loader: 'ts-loader',
-						options: {
-							instance: 'dojo',
-							onlyCompileBundledFiles: true
-						}
-					}
-				]},
-				{ test: /\.js?$/, use: [
-					{
-						loader: '@dojo/webpack-contrib/static-build-loader',
-						options: {
-							features: args.features
-						}
-					},
-					'umd-compat-loader'
-				]},
+					]
+				},
+				{
+					test: /\.js?$/,
+					use: [
+						{
+							loader: '@dojo/webpack-contrib/static-build-loader',
+							options: {
+								features: args.features
+							}
+						},
+						'umd-compat-loader'
+					]
+				},
 				{ test: new RegExp(`globalize(\\${path.sep}|$)`), loader: 'imports-loader?define=>false' },
 				...includeWhen(!args.element, () => {
-					return [
-						{ test: /\.html$/, loader: 'html-loader' }
-					];
+					return [{ test: /\.html$/, loader: 'html-loader' }];
 				}),
-				{ test: /.*\.(gif|png|jpe?g|svg|eot|ttf|woff|woff2)$/i, loader: 'file-loader?hash=sha512&digest=hex&name=[hash:base64:8].[ext]' },
+				{
+					test: /.*\.(gif|png|jpe?g|svg|eot|ttf|woff|woff2)$/i,
+					loader: 'file-loader?hash=sha512&digest=hex&name=[hash:base64:8].[ext]'
+				},
 				{ test: /\.css$/, exclude: /src[\\\/].*/, loader: cssLoader },
 				{ test: /src[\\\/].*\.css?$/, loader: cssModuleLoader },
 				{ test: /\.m\.css\.js$/, exclude: /src[\\\/].*/, use: ['json-css-module-loader'] },
 				...includeWhen(args.withTests, () => {
 					return [
-						{ test: /tests[\\\/].*\.ts?$/, use: [
-							'umd-compat-loader',
-							{
-								loader: 'ts-loader',
-								options: {
-									instance: 'dojo',
-									onlyCompileBundledFiles: true
+						{
+							test: /tests[\\\/].*\.ts?$/,
+							use: [
+								'umd-compat-loader',
+								{
+									loader: 'ts-loader',
+									options: {
+										instance: 'dojo',
+										onlyCompileBundledFiles: true
+									}
 								}
-							}
-						] },
+							]
+						},
 						{
 							test: /src\/.*\.ts$/,
 							use: {
@@ -394,22 +450,20 @@ function webpackConfig(args: Partial<BuildArgs>) {
 						}
 					];
 				}),
-				...includeWhen(args.element, args => {
-					return [
-						{ test: /custom-element\.js/, loader: `imports-loader?widgetFactory=${args.element}` }
-					];
+				...includeWhen(args.element, (args) => {
+					return [{ test: /custom-element\.js/, loader: `imports-loader?widgetFactory=${args.element}` }];
 				}),
 				...includeWhen(args.bundles && Object.keys(args.bundles).length, () => {
 					const loaders: any[] = [];
 
-					Object.keys(args.bundles || {}).forEach(bundleName => {
-						(args.bundles || {})[ bundleName ].forEach(fileName => {
+					Object.keys(args.bundles || {}).forEach((bundleName) => {
+						(args.bundles || {})[bundleName].forEach((fileName) => {
 							loaders.push({
 								test: /main\.ts/,
 								loader: {
 									loader: 'imports-loader',
 									options: {
-										'__manual_bundle__': `bundle-loader?lazy&name=${bundleName}!${fileName}`
+										__manual_bundle__: `bundle-loader?lazy&name=${bundleName}!${fileName}`
 									}
 								}
 							});

--- a/src/webpack.d.ts
+++ b/src/webpack.d.ts
@@ -26,7 +26,11 @@ declare module 'tapable' {
 		protected applyPluginsWaterfall(name: string, initial: any, ...args: any[]): any;
 		protected applyPluginsAsync(name: string, ...args: any[]): void;
 		protected applyPluginsBailResult(name: string, ...args: any[]): any;
-		protected applyPluginsAsyncWaterfall(name: string, initial: any, callback: (error: Error | null, value: any) => void): void;
+		protected applyPluginsAsyncWaterfall(
+			name: string,
+			initial: any,
+			callback: (error: Error | null, value: any) => void
+		): void;
 		protected applyPluginsAsyncSeries(name: string, ...args: any[]): void;
 		protected applyPluginsAsyncSeriesBailResult(name: string, ...args: any[]): void;
 		protected applyPluginsParallel(name: string, ...args: any[]): void;
@@ -53,7 +57,7 @@ declare module 'webpack/lib/DefinePlugin' {
 	import webpack = require('webpack');
 
 	class DefinePlugin implements webpack.Plugin {
-		constructor(definitions: { [key: string]: string; });
+		constructor(definitions: { [key: string]: string });
 		apply(compiler: webpack.Compiler): void;
 	}
 	export = DefinePlugin;
@@ -66,7 +70,7 @@ declare module 'webpack-sources/lib/Source' {
 		map(options: Source.Options): string;
 		size(): number;
 		source(): string;
-		sourceAndMap(options: Source.Options): { code: string; map: any; };
+		sourceAndMap(options: Source.Options): { code: string; map: any };
 		updateHash(hash: crypto.Hash): void;
 	}
 
@@ -148,10 +152,30 @@ declare module 'webpack/lib/webpack' {
 				packageMains?: string[];
 				moduleExtensions?: string[];
 			};
-			devtool?: false | 'eval' | 'cheap-eval-source-map' | 'cheap-source-map' | 'cheap-module-eval-source-map' | 'cheap-module-source-map' | 'eval-source-map' | 'source-map' | 'nosources-source-map' | 'inline-source-map' | 'hidden-source-map';
+			devtool?:
+				| false
+				| 'eval'
+				| 'cheap-eval-source-map'
+				| 'cheap-source-map'
+				| 'cheap-module-eval-source-map'
+				| 'cheap-module-source-map'
+				| 'eval-source-map'
+				| 'source-map'
+				| 'nosources-source-map'
+				| 'inline-source-map'
+				| 'hidden-source-map';
 			context?: string;
-			target?: 'async-node' | 'electron-main' | 'electron-renderer' | 'node' | 'node-webkit' | 'web' | 'webworker';
-			externals?: { [key: string]: string | string[] | Object } | ((context: string, request: string, callback: Function) => void)[];
+			target?:
+				| 'async-node'
+				| 'electron-main'
+				| 'electron-renderer'
+				| 'node'
+				| 'node-webkit'
+				| 'web'
+				| 'webworker';
+			externals?:
+				| { [key: string]: string | string[] | Object }
+				| ((context: string, request: string, callback: Function) => void)[];
 			stats?: Stats;
 			plugins?: Plugin[];
 			profile?: boolean;
@@ -205,7 +229,18 @@ declare module 'webpack/lib/webpack' {
 			filename: string;
 			publicPath?: string;
 			library?: string;
-			libraryTarget?: 'var' |	'this' | 'window' | 'global' | 'commonjs' | 'commonjs2' | 'commonjs-module' | 'amd' | 'umd' | 'assign' | 'jsonp';
+			libraryTarget?:
+				| 'var'
+				| 'this'
+				| 'window'
+				| 'global'
+				| 'commonjs'
+				| 'commonjs2'
+				| 'commonjs-module'
+				| 'amd'
+				| 'umd'
+				| 'assign'
+				| 'jsonp';
 			pathinfo?: boolean;
 			chunkFilename?: string;
 			jsonpFunction?: string;
@@ -219,9 +254,9 @@ declare module 'webpack/lib/webpack' {
 			apply(compiler?: WebpackCompiler): void;
 		}
 		interface Resolve {
-			alias?: { [key: string]: string; };
+			alias?: { [key: string]: string };
 			aliasFields?: string[];
-			cachePredicate?: (info: { path: string; request: string; }) => boolean;
+			cachePredicate?: (info: { path: string; request: string }) => boolean;
 			descriptionFiles?: string[];
 			enforceExtension?: boolean;
 			enforceModuleExtension?: boolean;
@@ -406,13 +441,22 @@ declare module 'webpack/lib/Compilation' {
 		constructor(compiler: Compiler);
 
 		addModule(module: Module, cacheGroup?: string): Module | boolean;
-		buildModule(module: Module, optional: boolean, origin: Module | null, dependencies: any[] | null, callback: (error?: Error) => void): void;
+		buildModule(
+			module: Module,
+			optional: boolean,
+			origin: Module | null,
+			dependencies: any[] | null,
+			callback: (error?: Error) => void
+		): void;
 		processModuleDependencies(module: Module, callback: (error?: Error) => void): void;
 
 		plugin(name: 'normal-module-loader', fn: (this: Compilation, loaderContext: any, module: Module) => void): void;
 		plugin(name: 'seal', fn: (this: Compilation) => void): void;
 		plugin(name: 'optimize', fn: (this: Compilation) => void): void;
-		plugin(name: 'optimize-tree', fn: (this: Compilation, chunks: Chunk[], modules: Module[], callback: (error?: Error) => void) => void): void;
+		plugin(
+			name: 'optimize-tree',
+			fn: (this: Compilation, chunks: Chunk[], modules: Module[], callback: (error?: Error) => void) => void
+		): void;
 		plugin(name: 'optimize-modules', fn: (this: Compilation, modules: Module[]) => any): void;
 		plugin(name: 'after-optimize-modules', fn: (this: Compilation, modules: Module[]) => void): void;
 		plugin(name: 'optimize-chunks', fn: (this: Compilation, chunks: Chunk[]) => any): void;
@@ -432,9 +476,15 @@ declare module 'webpack/lib/Compilation' {
 		plugin(name: 'before-chunk-assets', fn: (this: Compilation) => void): void;
 		plugin(name: 'additional-chunk-assets', fn: (this: Compilation, chunks: Chunk[]) => void): void;
 		plugin(name: 'record', fn: (this: Compilation, compilation: Compilation, records: any) => void): void;
-		plugin(name: 'optimize-chunk-assets', fn: (this: Compilation, chunks: Chunk[], callback: (error?: Error) => void) => void): void;
+		plugin(
+			name: 'optimize-chunk-assets',
+			fn: (this: Compilation, chunks: Chunk[], callback: (error?: Error) => void) => void
+		): void;
 		plugin(name: 'after-optimize-chunk-assets', fn: (this: Compilation, chunks: Chunk[]) => void): void;
-		plugin(name: 'optimize-assets', fn: (this: Compilation, assets: { [key: string]: Source }, callback: (error?: Error) => void) => void): void;
+		plugin(
+			name: 'optimize-assets',
+			fn: (this: Compilation, assets: { [key: string]: Source }, callback: (error?: Error) => void) => void
+		): void;
 		plugin(name: 'after-optimize-assets', fn: (this: Compilation, assets: { [key: string]: Source }) => void): void;
 		plugin(name: 'build-module', fn: (this: Compilation, module: Module) => void): void;
 		plugin(name: 'succeed-module', fn: (this: Compilation, module: Module) => void): void;
@@ -471,7 +521,10 @@ declare module 'webpack/lib/Compiler' {
 		plugin(name: 'run', fn: (this: Compiler, compiler: Compiler) => void): void;
 		plugin(name: 'emit', fn: (this: Compiler, compilation: Compilation) => void): void;
 		plugin(name: 'after-emit', fn: (this: Compiler, compilation: Compilation) => void): void;
-		plugin(name: 'compilation', fn: (this: Compiler, compilation: Compilation, params: Compiler.CompilationParams) => void): void;
+		plugin(
+			name: 'compilation',
+			fn: (this: Compiler, compilation: Compilation, params: Compiler.CompilationParams) => void
+		): void;
 		plugin(name: 'normal-module-factory', fn: (this: Compiler, factory: NormalModuleFactory) => void): void;
 		plugin(name: 'context-module-factory', fn: (this: Compiler, factory: ContextModuleFactory) => void): void;
 		plugin(name: 'compile', fn: (this: Compiler, params: any) => void): void;
@@ -519,7 +572,12 @@ declare module 'webpack/lib/ContextReplacementPlugin' {
 	import webpack = require('webpack');
 
 	class ContextReplacementPlugin implements webpack.Plugin {
-		constructor(resourceRegExp: RegExp, newContentResource?: any, newContentRecursive?: any, newContentRegExp?: any);
+		constructor(
+			resourceRegExp: RegExp,
+			newContentResource?: any,
+			newContentRecursive?: any,
+			newContentRegExp?: any
+		);
 		apply(compiler: webpack.Compiler): void;
 	}
 	export = ContextReplacementPlugin;
@@ -574,7 +632,7 @@ declare module 'webpack/lib/Dependency' {
 		module: Module;
 
 		isEqualResource(): boolean;
-		getReference(): { module: Module; importedNames: boolean; } | null;
+		getReference(): { module: Module; importedNames: boolean } | null;
 		getExports(): string[] | null;
 		getWarnings(): string[] | null;
 		getErrors(): string[] | null;
@@ -622,9 +680,36 @@ declare module 'webpack/lib/ModuleTemplate' {
 	import * as crypto from 'crypto';
 
 	class ModuleTemplate extends Template {
-		plugin(name: 'module', fn: (this: ModuleTemplate, moduleSource: Source, module: Module, chunk: Chunk, dependencyTemplates: Template[]) => Source): void;
-		plugin(name: 'render', fn: (this: ModuleTemplate, moduleSource: Source, module: Module, chunk: Chunk, dependencyTemplates: Template[]) => Source): void;
-		plugin(name: 'package', fn: (this: ModuleTemplate, moduleSource: Source, module: Module, chunk: Chunk, dependencyTemplates: Template[]) => Source): void;
+		plugin(
+			name: 'module',
+			fn: (
+				this: ModuleTemplate,
+				moduleSource: Source,
+				module: Module,
+				chunk: Chunk,
+				dependencyTemplates: Template[]
+			) => Source
+		): void;
+		plugin(
+			name: 'render',
+			fn: (
+				this: ModuleTemplate,
+				moduleSource: Source,
+				module: Module,
+				chunk: Chunk,
+				dependencyTemplates: Template[]
+			) => Source
+		): void;
+		plugin(
+			name: 'package',
+			fn: (
+				this: ModuleTemplate,
+				moduleSource: Source,
+				module: Module,
+				chunk: Chunk,
+				dependencyTemplates: Template[]
+			) => Source
+		): void;
 		plugin(name: 'hash', fn: (this: ModuleTemplate, hash: crypto.Hash) => void): void;
 	}
 
@@ -644,7 +729,14 @@ declare module 'webpack/lib/NormalModule' {
 		context: any;
 		loaders: string[];
 
-		constructor(request: string, userRequest: string, rawRequest: string, loaders: string[], resource: string, parser: Parser);
+		constructor(
+			request: string,
+			userRequest: string,
+			rawRequest: string,
+			loaders: string[],
+			resource: string,
+			parser: Parser
+		);
 	}
 
 	export = NormalModule;
@@ -676,7 +768,10 @@ declare module 'webpack/lib/NormalModuleFactory' {
 		plugin(name: 'after-resolve', fn: NormalModuleFactory.AfterHandler): void;
 		plugin(name: 'before-resolve', fn: NormalModuleFactory.BeforeHandler): void;
 		plugin(name: 'parser', fn: (this: NormalModuleFactory, parser: Parser, options: any) => void): void;
-		plugin(name: 'resolver', fn: (this: NormalModuleFactory, resolver: NormalModuleFactory.Resolver) => NormalModuleFactory.Resolver): void;
+		plugin(
+			name: 'resolver',
+			fn: (this: NormalModuleFactory, resolver: NormalModuleFactory.Resolver) => NormalModuleFactory.Resolver
+		): void;
 	}
 	namespace NormalModuleFactory {
 		interface BeforeData {
@@ -764,7 +859,7 @@ declare module 'webpack/lib/optimize/CommonsChunkPlugin' {
 		constructor(options: CommonsChunkPlugin.Options);
 		apply(compiler: webpack.Compiler): void;
 	}
-	module CommonsChunkPlugin {
+	namespace CommonsChunkPlugin {
 		interface Options {
 			name?: string;
 			names?: string[];
@@ -786,7 +881,7 @@ declare module 'webpack/lib/optimize/UglifyJsPlugin' {
 		constructor(options?: UglifyJsPlugin.Options);
 		apply(compiler: webpack.Compiler): void;
 	}
-	module UglifyJsPlugin {
+	namespace UglifyJsPlugin {
 		type CommentCallback = (astNode: any, comment: any) => boolean;
 		interface Compress {
 			sequences?: boolean;
@@ -807,7 +902,7 @@ declare module 'webpack/lib/optimize/UglifyJsPlugin' {
 			cascade?: boolean;
 			side_effects?: boolean;
 			warnings?: boolean;
-			global_defs?: { [key: string]: boolean; };
+			global_defs?: { [key: string]: boolean };
 		}
 		interface ExtractComments {
 			condition?: RegExp | string | CommentCallback;

--- a/tests/support/MockModule.ts
+++ b/tests/support/MockModule.ts
@@ -33,7 +33,7 @@ export default class MockModule {
 
 				for (let prop in module) {
 					if (typeof module[prop] === 'function') {
-						mock[prop] = function () {};
+						mock[prop] = function() {};
 						this.sandbox.stub(mock, prop);
 					} else {
 						mock[prop] = module[prop];
@@ -45,13 +45,11 @@ export default class MockModule {
 					Object.assign(ctor, mock);
 					mockery.registerMock(dependency, ctor);
 					mock.ctor = ctor;
-				}
-				else {
+				} else {
 					mockery.registerMock(dependency, mock);
 				}
 				this.mocks[dependency] = mock;
-			}
-			else {
+			} else {
 				const { name, mock } = dependency;
 				mockery.registerMock(name, mock);
 				this.mocks[name] = mock;

--- a/tests/support/lazy-load/simple.ts
+++ b/tests/support/lazy-load/simple.ts
@@ -4,8 +4,8 @@ declare const require: any;
 
 export default function doTheThing(fn: any) {
 	fn();
-};
+}
 
-doTheThing(function () {
-	return load(require, './some-module').then(([ module ]) => module.default);
+doTheThing(function() {
+	return load(require, './some-module').then(([module]) => module.default);
 });

--- a/tests/support/lazy-load/some-module.ts
+++ b/tests/support/lazy-load/some-module.ts
@@ -1,2 +1,1 @@
-export default function test() {
-}
+export default function test() {}

--- a/tests/support/lazy-load/with-define.ts
+++ b/tests/support/lazy-load/with-define.ts
@@ -3,10 +3,9 @@ import load from '@dojo/core/load';
 declare const require: any;
 
 const registry = {
-	define: function (one: string, two: any) {
-	}
+	define: function(one: string, two: any) {}
 };
 
-registry.define('some-module', function () {
-	return load(require, './some-module').then(([ module ]) => module.default);
+registry.define('some-module', function() {
+	return load(require, './some-module').then(([module]) => module.default);
 });

--- a/tests/support/util.ts
+++ b/tests/support/util.ts
@@ -9,11 +9,14 @@ export interface Thenable<T> {
 }
 
 export function isEventuallyRejected<T>(promise: Thenable<T>): Thenable<boolean> {
-	return promise.then<any>(function () {
-		throw new Error('unexpected code path');
-	}, function () {
-		return true; // expect rejection
-	});
+	return promise.then<any>(
+		function() {
+			throw new Error('unexpected code path');
+		},
+		function() {
+			return true; // expect rejection
+		}
+	);
 }
 
 export function throwImmediately() {
@@ -38,7 +41,7 @@ export function fetchCldrData(locales: string | string[]): CldrData {
 		'cldr-data/supplemental/likelySubtags.json'
 	];
 
-	locales = Array.isArray(locales) ? locales : [ locales ];
+	locales = Array.isArray(locales) ? locales : [locales];
 	locales.forEach((locale: string) => {
 		urls.forEach((url: string) => {
 			deepAssign(data, require(url.replace('{locale}', locale)));

--- a/tests/support/webpack/Compilation.ts
+++ b/tests/support/webpack/Compilation.ts
@@ -18,7 +18,7 @@ class MockCompilation extends Pluginable {
 		super();
 		this.options = options || {
 			resolve: {
-				modules: [ '/root/path' ]
+				modules: ['/root/path']
 			}
 		};
 	}

--- a/tests/support/webpack/Compiler.ts
+++ b/tests/support/webpack/Compiler.ts
@@ -14,7 +14,7 @@ class MockCompiler extends Pluginable {
 		this.applied = [];
 		this.options = options || {
 			resolve: {
-				modules: [ '/root/path' ]
+				modules: ['/root/path']
 			}
 		};
 		this.watchFileSystem = {};

--- a/tests/support/webpack/NormalModule.ts
+++ b/tests/support/webpack/NormalModule.ts
@@ -14,7 +14,14 @@ class MockNormalModule {
 	resource: string;
 	parser: any;
 
-	constructor(request: string, userRequest: string, rawRequest: string, loaders: string[], resource: string, parser: any) {
+	constructor(
+		request: string,
+		userRequest: string,
+		rawRequest: string,
+		loaders: string[],
+		resource: string,
+		parser: any
+	) {
 		this.isBuilt = false;
 		this.chunks = [];
 		this.dependencies = [];

--- a/tests/unit/loaders/istanbul-loader.ts
+++ b/tests/unit/loaders/istanbul-loader.ts
@@ -6,7 +6,7 @@ const { assert } = intern.getPlugin('chai');
 
 function getSourceMap() {
 	return {
-		sources: [ 'some/path!myFile.ts', 'myFile2.ts' ]
+		sources: ['some/path!myFile.ts', 'myFile2.ts']
 	};
 }
 
@@ -21,9 +21,7 @@ describe('istanbul-loader', () => {
 	beforeEach(() => {
 		sandbox = sinon.sandbox.create();
 		mockModule = new MockModule('../../../src/loaders/istanbul-loader/loader', require);
-		mockModule.dependencies([
-			'istanbul-lib-instrument'
-		]);
+		mockModule.dependencies(['istanbul-lib-instrument']);
 		mockIstanbul = mockModule.getMock('istanbul-lib-instrument');
 		instrumentMock = sandbox.stub().callsArg(2);
 		sourceMapMock = sandbox.stub().returns({});
@@ -41,11 +39,15 @@ describe('istanbul-loader', () => {
 
 	it('should call istanbul to instrument files', () => {
 		return new Promise((resolve, reject) => {
-			loaderUnderTest.call({
-				async() {
-					return () => resolve();
-				}
-			}, 'content', getSourceMap());
+			loaderUnderTest.call(
+				{
+					async() {
+						return () => resolve();
+					}
+				},
+				'content',
+				getSourceMap()
+			);
 		}).then(() => {
 			assert.isTrue(instrumentMock.calledOnce);
 		});
@@ -53,11 +55,15 @@ describe('istanbul-loader', () => {
 
 	it('handles no source map', () => {
 		return new Promise((resolve, reject) => {
-			loaderUnderTest.call({
-				async() {
-					return () => resolve();
-				}
-			}, 'content', null);
+			loaderUnderTest.call(
+				{
+					async() {
+						return () => resolve();
+					}
+				},
+				'content',
+				null
+			);
 		}).then(() => {
 			assert.isTrue(instrumentMock.calledOnce);
 		});
@@ -65,11 +71,15 @@ describe('istanbul-loader', () => {
 
 	it('handles a source map with no sources', () => {
 		return new Promise((resolve, reject) => {
-			loaderUnderTest.call({
-				async() {
-					return () => resolve();
-				}
-			}, 'content', {});
+			loaderUnderTest.call(
+				{
+					async() {
+						return () => resolve();
+					}
+				},
+				'content',
+				{}
+			);
 		}).then(() => {
 			assert.isTrue(instrumentMock.calledOnce);
 		});
@@ -82,21 +92,23 @@ describe('istanbul-loader', () => {
 		sourceMapMock.returns(sourceMap);
 
 		return new Promise((resolve, reject) => {
-			loaderUnderTest.call({
-				async() {
-					return () => resolve();
-				}
-			}, 'content', sourceMap);
+			loaderUnderTest.call(
+				{
+					async() {
+						return () => resolve();
+					}
+				},
+				'content',
+				sourceMap
+			);
 		}).then(() => {
-			assert.deepEqual(sourceMap.sources, [ 'myFile.ts', 'myFile2.ts' ]);
+			assert.deepEqual(sourceMap.sources, ['myFile.ts', 'myFile2.ts']);
 		});
 	});
 
 	it('exports the loader in the index file', () => {
 		mockModule = new MockModule('../../../src/loaders/istanbul-loader/index', require);
-		mockModule.dependencies([
-			'./loader'
-		]);
+		mockModule.dependencies(['./loader']);
 
 		assert.isDefined(mockModule.getModuleUnderTest());
 	});

--- a/tests/unit/main.ts
+++ b/tests/unit/main.ts
@@ -7,7 +7,6 @@ const { assert } = intern.getPlugin('chai');
 const { afterEach, beforeEach, describe, it } = intern.getInterface('bdd');
 
 describe('main', () => {
-
 	let moduleUnderTest: any;
 	let mockModule: MockModule;
 	let mockWebpack: any;
@@ -38,10 +37,7 @@ describe('main', () => {
 		mockWebpackConfigModule = mockModule.getMock('./webpack.config').ctor;
 		mockWebpackConfig = {
 			entry: {
-				'src/main': [
-					'src/main.styl',
-					'src/main.ts'
-				]
+				'src/main': ['src/main.styl', 'src/main.ts']
 			}
 		};
 		mockWebpackConfigModule.returns(mockWebpackConfig);
@@ -67,13 +63,12 @@ describe('main', () => {
 				},
 				listen() {
 					if (inUse) {
-						callbacks['error']({code: errorCode, message: 'test error'});
+						callbacks['error']({ code: errorCode, message: 'test error' });
 					} else {
 						callbacks['listening']();
 					}
 				},
-				close() {
-				}
+				close() {}
 			};
 		};
 	}
@@ -88,14 +83,13 @@ describe('main', () => {
 					callbacks[event] = fn;
 				},
 				listen(port: number) {
-					if (ports.find(p => p === port)) {
-						callbacks['error']({code: 'EADDRINUSE', message: 'test error'});
+					if (ports.find((p) => p === port)) {
+						callbacks['error']({ code: 'EADDRINUSE', message: 'test error' });
 					} else {
 						callbacks['listening']();
 					}
 				},
-				close() {
-				}
+				close() {}
 			};
 		};
 	}
@@ -106,7 +100,7 @@ describe('main', () => {
 
 		function assureArgument(arg: string) {
 			const supportedArgs = options.args.filter((args) => {
-				return args[ 0 ] === arg;
+				return args[0] === arg;
 			});
 
 			assert.lengthOf(supportedArgs, 1);
@@ -129,7 +123,7 @@ describe('main', () => {
 		mockWebpack.returns({ run });
 		return moduleUnderTest.run(getMockConfiguration(), {}).then(() => {
 			assert.isTrue(run.calledOnce);
-			assert.isTrue((<sinon.SinonStub> console.log).calledWith('some stats'));
+			assert.isTrue((<sinon.SinonStub>console.log).calledWith('some stats'));
 		});
 	});
 
@@ -139,24 +133,27 @@ describe('main', () => {
 				return 'some stats';
 			},
 			compilation: {
-				errors: [ 'some error' ]
+				errors: ['some error']
 			}
 		});
 		mockWebpack.returns({ run });
-		return moduleUnderTest.run(getMockConfiguration(), {}).then(() => {
-			throw new Error('shouldnt have succeeded');
-		}, () => {
-			assert.isTrue(run.calledOnce);
-			assert.isTrue((<sinon.SinonStub> console.log).calledWith('some stats'));
-		});
+		return moduleUnderTest.run(getMockConfiguration(), {}).then(
+			() => {
+				throw new Error('shouldnt have succeeded');
+			},
+			() => {
+				assert.isTrue(run.calledOnce);
+				assert.isTrue((<sinon.SinonStub>console.log).calledWith('some stats'));
+			}
+		);
 	});
 
-	it('should not print stats if they aren\'t there', () => {
+	it("should not print stats if they aren't there", () => {
 		const run = sandbox.stub().yields(false, null);
 		mockWebpack.returns({ run });
 		return moduleUnderTest.run(getMockConfiguration(), {}).then(() => {
 			assert.isTrue(run.calledOnce);
-			assert.isFalse((<sinon.SinonStub> console.log).called);
+			assert.isFalse((<sinon.SinonStub>console.log).called);
 		});
 	});
 
@@ -164,13 +161,10 @@ describe('main', () => {
 		const compilerError = new Error('compiler error');
 		const run = sandbox.stub().yields(compilerError, null);
 		mockWebpack.returns({ run });
-		return moduleUnderTest.run(getMockConfiguration(), {}).then(
-			throwImmediately,
-			(e: Error) => {
-				assert.isTrue(run.calledOnce);
-				assert.equal(e, compilerError);
-			}
-		);
+		return moduleUnderTest.run(getMockConfiguration(), {}).then(throwImmediately, (e: Error) => {
+			assert.isTrue(run.calledOnce);
+			assert.equal(e, compilerError);
+		});
 	});
 
 	it('should run watch, setting appropriate webpack options', () => {
@@ -180,7 +174,9 @@ describe('main', () => {
 		moduleUnderTest.run(getMockConfiguration(), { watch: true });
 		return new Promise((resolve) => setTimeout(resolve, 10)).then(() => {
 			assert.isTrue(mockWebpackDevServer.listen.calledOnce);
-			assert.isTrue((<sinon.SinonStub> console.log).firstCall.calledWith('Starting server on http://localhost:9999'));
+			assert.isTrue(
+				(<sinon.SinonStub>console.log).firstCall.calledWith('Starting server on http://localhost:9999')
+			);
 			assert.equal(mockWebpackConfig.devtool, 'inline-source-map');
 			assert.equal(mockWebpackConfig.entry['src/main'][0], 'webpack-dev-server/client?');
 		});
@@ -190,24 +186,18 @@ describe('main', () => {
 		const mockWebpackDevServer = mockModule.getMock('webpack-dev-server');
 		mockWebpackDevServer.listen = sandbox.stub().yields();
 		markPortAsInUse(true);
-		return moduleUnderTest.run(getMockConfiguration(), { watch: true }).then(
-			throwImmediately,
-			(e: Error) => {
-				assert.isTrue(e.message.indexOf('in use') >= 0);
-			}
-		);
+		return moduleUnderTest.run(getMockConfiguration(), { watch: true }).then(throwImmediately, (e: Error) => {
+			assert.isTrue(e.message.indexOf('in use') >= 0);
+		});
 	});
 
 	it('should run watch and reject on any listening error', () => {
 		const mockWebpackDevServer = mockModule.getMock('webpack-dev-server');
 		mockWebpackDevServer.listen = sandbox.stub().yields();
 		markPortAsInUse(true, 'SOMEERROR');
-		return moduleUnderTest.run(getMockConfiguration(), { watch: true }).then(
-			throwImmediately,
-			(e: Error) => {
-				assert.strictEqual(e.message, 'Unexpected error test error');
-			}
-		);
+		return moduleUnderTest.run(getMockConfiguration(), { watch: true }).then(throwImmediately, (e: Error) => {
+			assert.strictEqual(e.message, 'Unexpected error test error');
+		});
 	});
 
 	it('should run watch and reject on failure', () => {
@@ -215,23 +205,23 @@ describe('main', () => {
 		const mockWebpackDevServer = mockModule.getMock('webpack-dev-server');
 		mockWebpackDevServer.listen = sandbox.stub().yields(compilerError);
 		markPortAsInUse(false);
-		return moduleUnderTest.run(getMockConfiguration(), { watch: true }).then(
-			throwImmediately,
-			(e: Error) => {
-				assert.isTrue(mockWebpackDevServer.listen.calledOnce);
-				assert.equal(e, compilerError);
-			}
-		);
+		return moduleUnderTest.run(getMockConfiguration(), { watch: true }).then(throwImmediately, (e: Error) => {
+			assert.isTrue(mockWebpackDevServer.listen.calledOnce);
+			assert.equal(e, compilerError);
+		});
 	});
 
 	it('should use a single port', () => {
 		const mockWebpackDevServer = mockModule.getMock('webpack-dev-server');
 		mockWebpackDevServer.listen = sandbox.stub().yields();
 		markPortsAsInUse([]);
-		moduleUnderTest.run(getMockConfiguration(), {watch: true, port: '123'});
+		moduleUnderTest.run(getMockConfiguration(), { watch: true, port: '123' });
 		return new Promise((resolve) => setTimeout(resolve, 10)).then(() => {
 			assert.isTrue(mockWebpackDevServer.listen.calledOnce, 'expected listen to be called on server');
-			assert.isTrue(mockWebpackDevServer.listen.firstCall.calledWith(123), 'expected listen to be called with port');
+			assert.isTrue(
+				mockWebpackDevServer.listen.firstCall.calledWith(123),
+				'expected listen to be called with port'
+			);
 		});
 	});
 
@@ -239,10 +229,13 @@ describe('main', () => {
 		const mockWebpackDevServer = mockModule.getMock('webpack-dev-server');
 		mockWebpackDevServer.listen = sandbox.stub().yields();
 		markPortsAsInUse([123]);
-		moduleUnderTest.run(getMockConfiguration(), {watch: true, port: '123,456'});
+		moduleUnderTest.run(getMockConfiguration(), { watch: true, port: '123,456' });
 		return new Promise((resolve) => setTimeout(resolve, 10)).then(() => {
 			assert.isTrue(mockWebpackDevServer.listen.calledOnce, 'expected listen to be called on server');
-			assert.isTrue(mockWebpackDevServer.listen.firstCall.calledWith(456), 'expected listen to be called with port');
+			assert.isTrue(
+				mockWebpackDevServer.listen.firstCall.calledWith(456),
+				'expected listen to be called with port'
+			);
 		});
 	});
 
@@ -250,10 +243,13 @@ describe('main', () => {
 		const mockWebpackDevServer = mockModule.getMock('webpack-dev-server');
 		mockWebpackDevServer.listen = sandbox.stub().yields();
 		markPortsAsInUse([456]);
-		moduleUnderTest.run(getMockConfiguration(), {watch: true, port: '456:454'});
+		moduleUnderTest.run(getMockConfiguration(), { watch: true, port: '456:454' });
 		return new Promise((resolve) => setTimeout(resolve, 10)).then(() => {
 			assert.isTrue(mockWebpackDevServer.listen.calledOnce, 'expected listen to be called on server');
-			assert.isTrue(mockWebpackDevServer.listen.firstCall.calledWith(455), 'expected listen to be called with port');
+			assert.isTrue(
+				mockWebpackDevServer.listen.firstCall.calledWith(455),
+				'expected listen to be called with port'
+			);
 		});
 	});
 
@@ -261,10 +257,13 @@ describe('main', () => {
 		const mockWebpackDevServer = mockModule.getMock('webpack-dev-server');
 		mockWebpackDevServer.listen = sandbox.stub().yields();
 		markPortsAsInUse([]);
-		moduleUnderTest.run(getMockConfiguration(), {watch: true, port: '454:456'});
+		moduleUnderTest.run(getMockConfiguration(), { watch: true, port: '454:456' });
 		return new Promise((resolve) => setTimeout(resolve, 10)).then(() => {
 			assert.isTrue(mockWebpackDevServer.listen.calledOnce, 'expected listen to be called on server');
-			assert.isTrue(mockWebpackDevServer.listen.firstCall.calledWith(456), 'expected listen to be called with port');
+			assert.isTrue(
+				mockWebpackDevServer.listen.firstCall.calledWith(456),
+				'expected listen to be called with port'
+			);
 		});
 	});
 
@@ -276,33 +275,41 @@ describe('main', () => {
 		});
 
 		it('should correctly set i18n options', () => {
-			return moduleUnderTest.run(getMockConfiguration(), {
-				cldrPaths: [ 'cldr-data/supplemental/likelySubtags.json' ],
-				locale: 'en',
-				supportedLocales: [ 'fr' ]
-			}).then(() => {
-				assert.isTrue(mockWebpackConfigModule.calledWith({
-					cldrPaths: [ 'cldr-data/supplemental/likelySubtags.json' ],
+			return moduleUnderTest
+				.run(getMockConfiguration(), {
+					cldrPaths: ['cldr-data/supplemental/likelySubtags.json'],
 					locale: 'en',
-					supportedLocales: [ 'fr' ]
-				}), JSON.stringify(mockWebpack.args));
-			});
+					supportedLocales: ['fr']
+				})
+				.then(() => {
+					assert.isTrue(
+						mockWebpackConfigModule.calledWith({
+							cldrPaths: ['cldr-data/supplemental/likelySubtags.json'],
+							locale: 'en',
+							supportedLocales: ['fr']
+						}),
+						JSON.stringify(mockWebpack.args)
+					);
+				});
 		});
 
 		it('should load options from .dojorc', () => {
 			const config = getMockConfiguration({
 				'build-webpack': {
-					cldrPaths: [ 'cldr-data/supplemental/likelySubtags.json' ],
+					cldrPaths: ['cldr-data/supplemental/likelySubtags.json'],
 					locale: 'en',
-					supportedLocales: [ 'fr' ]
+					supportedLocales: ['fr']
 				}
 			});
 			return moduleUnderTest.run(config, {}).then(() => {
-				assert.isTrue(mockWebpackConfigModule.calledWith({
-					cldrPaths: [ 'cldr-data/supplemental/likelySubtags.json' ],
-					locale: 'en',
-					supportedLocales: [ 'fr' ]
-				}), JSON.stringify(mockWebpack.args));
+				assert.isTrue(
+					mockWebpackConfigModule.calledWith({
+						cldrPaths: ['cldr-data/supplemental/likelySubtags.json'],
+						locale: 'en',
+						supportedLocales: ['fr']
+					}),
+					JSON.stringify(mockWebpack.args)
+				);
 			});
 		});
 
@@ -312,36 +319,46 @@ describe('main', () => {
 					supportedLocales: 'fr'
 				}
 			});
-			return moduleUnderTest.run(config, {
-				locale: 'en',
-				supportedLocales: [ 'fr', 'es' ]
-			}).then(() => {
-				assert.isTrue(mockWebpackConfigModule.calledWith({
+			return moduleUnderTest
+				.run(config, {
 					locale: 'en',
-					supportedLocales: [ 'fr', 'es' ]
-				}), JSON.stringify(mockWebpack.args));
-			});
+					supportedLocales: ['fr', 'es']
+				})
+				.then(() => {
+					assert.isTrue(
+						mockWebpackConfigModule.calledWith({
+							locale: 'en',
+							supportedLocales: ['fr', 'es']
+						}),
+						JSON.stringify(mockWebpack.args)
+					);
+				});
 		});
 
 		it('should not override .dojorc with undefined values', () => {
 			const config = getMockConfiguration({
 				'build-webpack': {
-					cldrPaths: [ 'cldr-data/supplemental/likelySubtags.json' ],
+					cldrPaths: ['cldr-data/supplemental/likelySubtags.json'],
 					locale: 'en',
-					supportedLocales: [ 'fr', 'es' ]
+					supportedLocales: ['fr', 'es']
 				}
 			});
-			return moduleUnderTest.run(config, {
-				cldrPaths: undefined,
-				locale: undefined,
-				supportedLocales: undefined
-			}).then(() => {
-				assert.isTrue(mockWebpackConfigModule.calledWith({
-					cldrPaths: [ 'cldr-data/supplemental/likelySubtags.json' ],
-					locale: 'en',
-					supportedLocales: [ 'fr', 'es' ]
-				}), JSON.stringify(mockWebpack.args));
-			});
+			return moduleUnderTest
+				.run(config, {
+					cldrPaths: undefined,
+					locale: undefined,
+					supportedLocales: undefined
+				})
+				.then(() => {
+					assert.isTrue(
+						mockWebpackConfigModule.calledWith({
+							cldrPaths: ['cldr-data/supplemental/likelySubtags.json'],
+							locale: 'en',
+							supportedLocales: ['fr', 'es']
+						}),
+						JSON.stringify(mockWebpack.args)
+					);
+				});
 		});
 	});
 
@@ -357,13 +374,18 @@ describe('main', () => {
 		});
 
 		it('should pass the profile option to webpack', () => {
-			return moduleUnderTest.run(getMockConfiguration(), {
-				debug: true
-			}).then(() => {
-				assert.isTrue(mockWebpackConfigModule.calledWith({
+			return moduleUnderTest
+				.run(getMockConfiguration(), {
 					debug: true
-				}), JSON.stringify(mockWebpack.args));
-			});
+				})
+				.then(() => {
+					assert.isTrue(
+						mockWebpackConfigModule.calledWith({
+							debug: true
+						}),
+						JSON.stringify(mockWebpack.args)
+					);
+				});
 		});
 
 		it('should create profile json file', () => {
@@ -371,23 +393,22 @@ describe('main', () => {
 
 			mockWebpackConfigModule.returns({
 				entry: {
-					'src/main': [
-						'src/main.styl',
-						'src/main.ts'
-					]
+					'src/main': ['src/main.styl', 'src/main.ts']
 				},
 				profile: true
 			});
 
-			return moduleUnderTest.run(getMockConfiguration(), {
-				debug: true
-			}).then(() => {
-				assert.isTrue(fsMock.called);
-				assert.strictEqual(fsMock.getCall(0).args[ 0 ], 'dist/profile.json');
-				assert.strictEqual(fsMock.getCall(0).args[ 1 ], '"test json"');
+			return moduleUnderTest
+				.run(getMockConfiguration(), {
+					debug: true
+				})
+				.then(() => {
+					assert.isTrue(fsMock.called);
+					assert.strictEqual(fsMock.getCall(0).args[0], 'dist/profile.json');
+					assert.strictEqual(fsMock.getCall(0).args[1], '"test json"');
 
-				fsMock.restore();
-			});
+					fsMock.restore();
+				});
 		});
 	});
 
@@ -399,72 +420,103 @@ describe('main', () => {
 		});
 
 		it('should set the element prefix based on the filename', () => {
-			return moduleUnderTest.run(getMockConfiguration(), {
-				'element': '/path/to/TestWidget.ts'
-			}).then(() => {
-				assert.isTrue(mockWebpackConfigModule.calledWith({
-					element: '/path/to/TestWidget.ts',
-					elementPrefix: 'test-widget'
-				}), JSON.stringify(mockWebpackConfigModule.args));
-			});
+			return moduleUnderTest
+				.run(getMockConfiguration(), {
+					element: '/path/to/TestWidget.ts'
+				})
+				.then(() => {
+					assert.isTrue(
+						mockWebpackConfigModule.calledWith({
+							element: '/path/to/TestWidget.ts',
+							elementPrefix: 'test-widget'
+						}),
+						JSON.stringify(mockWebpackConfigModule.args)
+					);
+				});
 		});
 
 		it('should handle a filename without an extension', () => {
-			return moduleUnderTest.run(getMockConfiguration(), {
-				'element': '/path/to/TestWidget'
-			}).then(() => {
-				assert.isTrue(mockWebpackConfigModule.calledWith({
-					element: '/path/to/TestWidget',
-					elementPrefix: 'test-widget'
-				}), JSON.stringify(mockWebpackConfigModule.args));
-			});
+			return moduleUnderTest
+				.run(getMockConfiguration(), {
+					element: '/path/to/TestWidget'
+				})
+				.then(() => {
+					assert.isTrue(
+						mockWebpackConfigModule.calledWith({
+							element: '/path/to/TestWidget',
+							elementPrefix: 'test-widget'
+						}),
+						JSON.stringify(mockWebpackConfigModule.args)
+					);
+				});
 		});
 
 		it('should support createXElement filename format', () => {
-			return moduleUnderTest.run(getMockConfiguration(), {
-				'element': '/path/to/createTestElement.ts'
-			}).then(() => {
-				assert.isTrue(mockWebpackConfigModule.calledWith({
-					element: '/path/to/createTestElement.ts',
-					elementPrefix: 'test'
-				}), JSON.stringify(mockWebpackConfigModule.args));
-			});
+			return moduleUnderTest
+				.run(getMockConfiguration(), {
+					element: '/path/to/createTestElement.ts'
+				})
+				.then(() => {
+					assert.isTrue(
+						mockWebpackConfigModule.calledWith({
+							element: '/path/to/createTestElement.ts',
+							elementPrefix: 'test'
+						}),
+						JSON.stringify(mockWebpackConfigModule.args)
+					);
+				});
 		});
 
 		it('should support createXElement filename format without an extension', () => {
-			return moduleUnderTest.run(getMockConfiguration(), {
-				'element': '/path/to/createTestElement'
-			}).then(() => {
-				assert.isTrue(mockWebpackConfigModule.calledWith({
-					element: '/path/to/createTestElement',
-					elementPrefix: 'test'
-				}), JSON.stringify(mockWebpackConfigModule.args));
-			});
+			return moduleUnderTest
+				.run(getMockConfiguration(), {
+					element: '/path/to/createTestElement'
+				})
+				.then(() => {
+					assert.isTrue(
+						mockWebpackConfigModule.calledWith({
+							element: '/path/to/createTestElement',
+							elementPrefix: 'test'
+						}),
+						JSON.stringify(mockWebpackConfigModule.args)
+					);
+				});
 		});
 
 		it('should allow the prefix to be specified', () => {
-			return moduleUnderTest.run(getMockConfiguration(), {
-				'element': '/path/to/TestWidget.ts',
-				'elementPrefix': 'my-widget'
-			}).then(() => {
-				assert.isTrue(mockWebpackConfigModule.calledWith({
+			return moduleUnderTest
+				.run(getMockConfiguration(), {
 					element: '/path/to/TestWidget.ts',
 					elementPrefix: 'my-widget'
-				}), JSON.stringify(mockWebpackConfigModule.args));
-			});
+				})
+				.then(() => {
+					assert.isTrue(
+						mockWebpackConfigModule.calledWith({
+							element: '/path/to/TestWidget.ts',
+							elementPrefix: 'my-widget'
+						}),
+						JSON.stringify(mockWebpackConfigModule.args)
+					);
+				});
 		});
 
 		it('should error if the element prefix cannot be determined', () => {
 			const exitMock = sandbox.stub(process, 'exit');
 
-			return moduleUnderTest.run(getMockConfiguration(), {
-				'element': '/path/to/'
-			}).then(() => {
-				assert.isTrue(exitMock.called);
-				assert.isTrue((<sinon.SinonStub> console.error).calledWith('Element prefix could not be determined from element name: "/path/to/". Use --elementPrefix to name element.'));
+			return moduleUnderTest
+				.run(getMockConfiguration(), {
+					element: '/path/to/'
+				})
+				.then(() => {
+					assert.isTrue(exitMock.called);
+					assert.isTrue(
+						(<sinon.SinonStub>console.error).calledWith(
+							'Element prefix could not be determined from element name: "/path/to/". Use --elementPrefix to name element.'
+						)
+					);
 
-				exitMock.restore();
-			});
+					exitMock.restore();
+				});
 		});
 	});
 
@@ -485,12 +537,12 @@ describe('main', () => {
 			assert.isTrue('devDependencies' in result.npm, 'expecting a devDependencies property');
 			assert.deepEqual(result.npm.devDependencies, {
 				'@dojo/cli-build-webpack': 'test-version',
-				'dep1': 'dep1v',
-				'dep2': 'dep2v'
+				dep1: 'dep1v',
+				dep2: 'dep2v'
 			});
 			assert.isTrue('copy' in result, 'expecting a copy property');
 			assert.isTrue('hints' in result, 'should provide build hints');
-			assert.deepEqual(result.copy.files, [ './webpack.config.js' ]);
+			assert.deepEqual(result.copy.files, ['./webpack.config.js']);
 		});
 	});
 });

--- a/tests/unit/plugins/IgnoreUnmodifiedPlugin.ts
+++ b/tests/unit/plugins/IgnoreUnmodifiedPlugin.ts
@@ -41,7 +41,7 @@ describe('IgnoreUnmodifiedPlugin', () => {
 		assert.strictEqual(onChange.callCount, 1);
 
 		for (let i = 1; i <= 10; i++) {
-			watcher._onChange(FILE_PATH, MTIME + (FS_ACCURACY * i));
+			watcher._onChange(FILE_PATH, MTIME + FS_ACCURACY * i);
 			assert.strictEqual(onChange.callCount, i + 1);
 		}
 	});
@@ -58,7 +58,7 @@ describe('IgnoreUnmodifiedPlugin', () => {
 		assert.strictEqual(onChange.callCount, 1);
 
 		for (let i = 1; i <= 10; i++) {
-			watcher._onChange(FILE_PATH, MTIME + (FS_ACCURACY * i));
+			watcher._onChange(FILE_PATH, MTIME + FS_ACCURACY * i);
 			assert.strictEqual(onChange.callCount, i + 1);
 		}
 	});

--- a/tests/unit/postcss.config.ts
+++ b/tests/unit/postcss.config.ts
@@ -14,10 +14,7 @@ let mockModule: MockModule;
 
 function start() {
 	mockModule = new MockModule('../../src/postcss.config', require);
-	mockModule.dependencies([
-		'postcss-cssnext',
-		'postcss-import'
-	]);
+	mockModule.dependencies(['postcss-cssnext', 'postcss-import']);
 	mockModule.start();
 
 	const exports = {};
@@ -27,7 +24,7 @@ function start() {
 		process: {
 			cwd: () => process.cwd()
 		},
-		require: (<any> require),
+		require: <any>require,
 		__dirname: dirname
 	});
 
@@ -52,13 +49,15 @@ describe('postcss.config.ts', () => {
 
 		it('should load postcss-cssnext', () => {
 			const mock = mockModule.getMock('postcss-cssnext');
-			assert.isTrue(mock.ctor.firstCall.calledWith({
-				features: {
-					autoprefixer: {
-						browsers: [ 'last 2 versions', 'ie >= 10' ]
+			assert.isTrue(
+				mock.ctor.firstCall.calledWith({
+					features: {
+						autoprefixer: {
+							browsers: ['last 2 versions', 'ie >= 10']
+						}
 					}
-				}
-			}));
+				})
+			);
 		});
 	});
 });

--- a/tests/unit/webpack.config.ts
+++ b/tests/unit/webpack.config.ts
@@ -56,7 +56,9 @@ function start(cli = true, args: Partial<BuildArgs> = {}) {
 		__dirname: dirname
 	});
 
-	let js = configString.toString('utf8').replace(/\$\{packagePath\}/g, dirname.replace(/\\/g, '/').replace(/^[cC]:/, ''));
+	let js = configString
+		.toString('utf8')
+		.replace(/\$\{packagePath\}/g, dirname.replace(/\\/g, '/').replace(/^[cC]:/, ''));
 
 	const shouldInstrument = intern.shouldInstrumentFile(resolve(basePath, 'src/webpack.config.js'));
 
@@ -73,7 +75,7 @@ function start(cli = true, args: Partial<BuildArgs> = {}) {
 
 	if (shouldInstrument) {
 		intern.emit('coverage', {
-			coverage: (<any> context)['__coverage__'],
+			coverage: (<any>context)['__coverage__'],
 			source: '',
 			sessionId: intern.config.sessionId
 		});
@@ -84,12 +86,14 @@ function getUMDCompatLoader(args = {}) {
 	start(true, args);
 	return config.module.rules.reduce((value: any, rule: any) => {
 		const loaders = rule.use || [];
-		return loaders.reduce((result: any, loader: any) => {
-			if (loader.loader === 'umd-compat-loader') {
-				return loader;
-			}
-			return result;
-		}, null) || value;
+		return (
+			loaders.reduce((result: any, loader: any) => {
+				if (loader.loader === 'umd-compat-loader') {
+					return loader;
+				}
+				return result;
+			}, null) || value
+		);
 	}, null);
 }
 
@@ -109,9 +113,11 @@ describe('webpack.config.ts', () => {
 
 		it('should remove previous build artifacts', () => {
 			const cleanPlugin = mockModule.getMock('clean-webpack-plugin');
-			assert.isTrue(cleanPlugin.ctor.calledWith([ '_build', 'dist' ], {
-				root: process.cwd()
-			}));
+			assert.isTrue(
+				cleanPlugin.ctor.calledWith(['_build', 'dist'], {
+					root: process.cwd()
+				})
+			);
 		});
 	}
 
@@ -151,23 +157,17 @@ describe('webpack.config.ts', () => {
 		it('can replace a require with promise-loader', () => {
 			const { options: { imports } } = getUMDCompatLoader({});
 			const result = imports('./TestModule', 'src/widgets');
-			assert.equal(
-				result,
-				`promise-loader?global,src${sep}widgets${sep}TestModule!./TestModule`
-			);
+			assert.equal(result, `promise-loader?global,src${sep}widgets${sep}TestModule!./TestModule`);
 		});
 
 		it('if bundle name passed, will include module in that bundle', () => {
 			const { options: { imports } } = getUMDCompatLoader({
 				bundles: {
-					'my-bundle': [ 'src/widgets/TestModule' ]
+					'my-bundle': ['src/widgets/TestModule']
 				}
 			});
 			const result = imports('./TestModule', `src/widgets`);
-			assert.equal(
-				result,
-				'promise-loader?global,my-bundle!./TestModule'
-			);
+			assert.equal(result, 'promise-loader?global,my-bundle!./TestModule');
 		});
 	});
 
@@ -203,48 +203,54 @@ describe('webpack.config.ts', () => {
 			start(true, {});
 			const loader = getTslintLoader();
 			assert.isDefined(loader);
-			assert.isTrue((<any> loader.options).emitErrors);
-			assert.isTrue((<any> loader.options).failOnHint);
+			assert.isTrue((<any>loader.options).emitErrors);
+			assert.isTrue((<any>loader.options).failOnHint);
 		});
 
 		it('will not cause build errors on linting warnings if watching', () => {
 			start(true, { watch: true });
 			const loader = getTslintLoader();
 			assert.isDefined(loader);
-			assert.isUndefined((<any> loader.options).emitErrors);
-			assert.isUndefined((<any> loader.options).failOnHint);
+			assert.isUndefined((<any>loader.options).emitErrors);
+			assert.isUndefined((<any>loader.options).failOnHint);
 		});
 
 		it('will not cause build errors on linting warnings if testing', () => {
 			start(true, { withTests: true });
 			const loader = getTslintLoader();
 			assert.isDefined(loader);
-			assert.isUndefined((<any> loader.options).emitErrors);
-			assert.isUndefined((<any> loader.options).failOnHint);
+			assert.isUndefined((<any>loader.options).emitErrors);
+			assert.isUndefined((<any>loader.options).failOnHint);
 		});
 	});
 
 	describe('external loader plugin', () => {
 		it('will pass external dependencies output path options to plugin', () => {
-			start(true, { externals: { dependencies: [ 'one' ], outputPath: 'foo' } });
-			const plugin = mockModule.getMock('@dojo/webpack-contrib/external-loader-plugin/ExternalLoaderPlugin').default;
+			start(true, { externals: { dependencies: ['one'], outputPath: 'foo' } });
+			const plugin = mockModule.getMock('@dojo/webpack-contrib/external-loader-plugin/ExternalLoaderPlugin')
+				.default;
 			assert.isTrue(plugin.calledOnce, 'Should have instantiated external loader plugin');
-			assert.deepEqual(plugin.firstCall.args, [ {
-				dependencies: [ 'one' ],
-				outputPath: 'foo',
-				pathPrefix: ''
-			} ]);
+			assert.deepEqual(plugin.firstCall.args, [
+				{
+					dependencies: ['one'],
+					outputPath: 'foo',
+					pathPrefix: ''
+				}
+			]);
 		});
 
 		it('will point external loader plugin to _build dir if building tests', () => {
-			start(true, { externals: { dependencies: [ 'one' ], outputPath: 'foo' }, withTests: true });
-			const plugin = mockModule.getMock('@dojo/webpack-contrib/external-loader-plugin/ExternalLoaderPlugin').default;
+			start(true, { externals: { dependencies: ['one'], outputPath: 'foo' }, withTests: true });
+			const plugin = mockModule.getMock('@dojo/webpack-contrib/external-loader-plugin/ExternalLoaderPlugin')
+				.default;
 			assert.isTrue(plugin.calledOnce, 'Should have instantiated external loader plugin');
-			assert.deepEqual(plugin.firstCall.args, [ {
-				dependencies: [ 'one' ],
-				outputPath: 'foo',
-				pathPrefix: '../_build/src'
-			} ]);
+			assert.deepEqual(plugin.firstCall.args, [
+				{
+					dependencies: ['one'],
+					outputPath: 'foo',
+					pathPrefix: '../_build/src'
+				}
+			]);
 		});
 	});
 
@@ -252,6 +258,6 @@ describe('webpack.config.ts', () => {
 		start(true, {});
 		const plugin = mockModule.getMock('@dojo/webpack-contrib/css-module-plugin/CssModulePlugin').default;
 		assert.isTrue(plugin.calledOnce, 'Should have instantiated css module plugin');
-		assert.deepEqual(plugin.firstCall.args, [ process.cwd() ], 'Should have passed the base path');
+		assert.deepEqual(plugin.firstCall.args, [process.cwd()], 'Should have passed the base path');
 	});
 });

--- a/tslint.json
+++ b/tslint.json
@@ -1,5 +1,7 @@
 {
+	"rulesDirectory": ["tslint-plugin-prettier"],
 	"rules": {
+		"prettier": true,
 		"align": false,
 		"ban": [],
 		"class-name": true,
@@ -30,15 +32,12 @@
 		"no-switch-case-fall-through": false,
 		"no-trailing-whitespace": true,
 		"no-unused-expression": false,
-		"no-unused-variable": true,
 		"no-use-before-declare": false,
 		"no-var-keyword": true,
 		"no-var-requires": false,
 		"object-literal-sort-keys": false,
 		"one-line": [ true, "check-open-brace", "check-whitespace" ],
-		"quotemark": [ true, "single" ],
 		"radix": true,
-		"semicolon": [ true, "always" ],
 		"trailing-comma": [ true, {
 			"multiline": "never",
 			"singleline": "never"
@@ -58,8 +57,6 @@
 			"property-declaration": "onespace",
 			"variable-declaration": "onespace"
 		} ],
-		"use-strict": false,
-		"variable-name": [ true, "check-format", "allow-pascal-case", "allow-leading-underscore", "ban-keywords" ],
-		"whitespace": [ true, "check-branch", "check-decl", "check-operator", "check-module", "check-separator", "check-type", "check-typecast" ]
+		"variable-name": [ true, "check-format", "allow-pascal-case", "allow-leading-underscore", "ban-keywords" ]
 	}
 }


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

**Description:**

Adds support for `Prettier` to for code style rules and formatting. Include precommit hook that runs prettier on all `.ts` files and an npm script that runs prettier against the codebase.

Related to https://github.com/dojo/meta/issues/206