### PR TITLE
Changed dojo cli flag to a string

### DIFF
--- a/src/webpack.config.ts
+++ b/src/webpack.config.ts
@@ -16,7 +16,7 @@ const OptimizeCssAssetsPlugin = require('optimize-css-assets-webpack-plugin');
 const BundleAnalyzerPlugin = require('webpack-bundle-analyzer-sunburst').BundleAnalyzerPlugin;
 const DefinePlugin = require('webpack/lib/DefinePlugin');
 
-const isCLI = process.env.DOJO_CLI === 'true';
+const isCLI = process.env.DOJO_ENV === 'cli';
 const packagePath = isCLI ? '.' : '@dojo/cli-build-webpack';
 const IgnoreUnmodifiedPlugin = require(`${packagePath}/plugins/IgnoreUnmodifiedPlugin`).default;
 const basePath = process.cwd();

--- a/src/webpack.config.ts
+++ b/src/webpack.config.ts
@@ -16,7 +16,7 @@ const OptimizeCssAssetsPlugin = require('optimize-css-assets-webpack-plugin');
 const BundleAnalyzerPlugin = require('webpack-bundle-analyzer-sunburst').BundleAnalyzerPlugin;
 const DefinePlugin = require('webpack/lib/DefinePlugin');
 
-const isCLI = process.env.DOJO_CLI;
+const isCLI = process.env.DOJO_CLI === 'true';
 const packagePath = isCLI ? '.' : '@dojo/cli-build-webpack';
 const IgnoreUnmodifiedPlugin = require(`${packagePath}/plugins/IgnoreUnmodifiedPlugin`).default;
 const basePath = process.cwd();

--- a/tests/unit/main.ts
+++ b/tests/unit/main.ts
@@ -29,7 +29,7 @@ describe('main', () => {
 	}
 
 	beforeEach(() => {
-		process.env.DOJO_CLI = true;
+		process.env.DOJO_CLI = 'true';
 
 		sandbox = sinon.sandbox.create();
 		mockModule = new MockModule('../../src/main', require);

--- a/tests/unit/main.ts
+++ b/tests/unit/main.ts
@@ -29,7 +29,7 @@ describe('main', () => {
 	}
 
 	beforeEach(() => {
-		process.env.DOJO_CLI = 'true';
+		process.env.DOJO_ENV = 'cli';
 
 		sandbox = sinon.sandbox.create();
 		mockModule = new MockModule('../../src/main', require);

--- a/tests/unit/webpack.config.ts
+++ b/tests/unit/webpack.config.ts
@@ -50,7 +50,7 @@ function start(cli = true, args: Partial<BuildArgs> = {}) {
 		exports,
 		process: {
 			cwd: () => process.cwd(),
-			env: { DOJO_CLI: cli }
+			env: { DOJO_CLI: cli ? 'true' : undefined }
 		},
 		require,
 		__dirname: dirname

--- a/tests/unit/webpack.config.ts
+++ b/tests/unit/webpack.config.ts
@@ -50,7 +50,7 @@ function start(cli = true, args: Partial<BuildArgs> = {}) {
 		exports,
 		process: {
 			cwd: () => process.cwd(),
-			env: { DOJO_CLI: cli ? 'true' : undefined }
+			env: { DOJO_ENV: cli ? 'cli' : undefined }
 		},
 		require,
 		__dirname: dirname


### PR DESCRIPTION
**Type:** bug / feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
Updated typings in CLI require the DOJO_CLI env flag to be a string.

Resolves #261
Requires: https://github.com/dojo/cli/issues/188

  